### PR TITLE
feat(getdocspaths): get docs paths considering locale folder

### DIFF
--- a/src/components/last-updates-card/index.tsx
+++ b/src/components/last-updates-card/index.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Text } from '@vtex/brand-ui'
 import type { ActionType, UpdateType } from './functions'
 import { getAction, getUpdate } from './functions'
 import { getDaysElapsed } from './../../utils/get-days-elapsed'
+import { useIntl } from 'react-intl'
 
 import styles from './styles'
 
@@ -18,6 +19,7 @@ export interface CardProps {
 
 const LastUpdatesCard = ({ action, updateType }: CardProps) => {
   const { title: actionTitle, Icon: ActionIcon } = getAction(action.type)
+  const intl = useIntl()
   const {
     title: updateTitle,
     description: updateDescription,
@@ -50,7 +52,9 @@ const LastUpdatesCard = ({ action, updateType }: CardProps) => {
           <Box sx={styles.actionDescriptionContainer}>
             <Text sx={styles.actionDescription}>{action.description}</Text>
             <Text sx={styles.actionTime}>
-              {`${getDaysElapsed(action.date)} days ago`}
+              {`${getDaysElapsed(action.date)} ${intl.formatMessage({
+                id: 'relese-note-days-elapsed',
+              })}`}
             </Text>
           </Box>
         </Box>

--- a/src/components/locale-switcher/index.tsx
+++ b/src/components/locale-switcher/index.tsx
@@ -31,6 +31,7 @@ export default function LocaleSwitcher() {
   const handleOptionClick = (option: string) => {
     const locale = option
     router.push(router.pathname, router.asPath, { locale })
+    disclosure.hide()
   }
   const disclosure = useDisclosureState({ visible: false })
   const Option = ({ screen, option, onClick, active }: OptionProps) => {

--- a/src/components/release-note/functions.tsx
+++ b/src/components/release-note/functions.tsx
@@ -8,9 +8,10 @@ import { FormattedMessage } from 'react-intl'
 export const getReleaseDate = (createdAt: string) => {
   const daysElapsed = getDaysElapsed(new Date(createdAt))
   return daysElapsed < 8 ? (
-    <Text sx={styles.releaseDate}>{`${getDaysElapsed(new Date(createdAt))} ${(
+    <Text sx={styles.releaseDate}>
+      {`${getDaysElapsed(new Date(createdAt))} `}
       <FormattedMessage id="relese-note-days-elapsed" />
-    )}`}</Text>
+    </Text>
   ) : (
     getDate(createdAt, false)
   )

--- a/src/components/release-note/index.tsx
+++ b/src/components/release-note/index.tsx
@@ -83,7 +83,7 @@ const ReleaseNote = ({
         }
       >
         <Flex sx={styles.content}>
-          <Link href={`release-notes/${slug}`} legacyBehavior>
+          <Link href={`announcements/${slug}`} legacyBehavior>
             <Text
               onMouseOver={handleMouseOver}
               onMouseLeave={handleMouseOut}

--- a/src/pages/docs/guides/[slug].tsx
+++ b/src/pages/docs/guides/[slug].tsx
@@ -170,6 +170,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({
   params,
+  locale,
   preview,
   previewData,
 }) => {
@@ -182,7 +183,7 @@ export const getStaticProps: GetStaticProps = async ({
   const docsPaths =
     process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
       ? docsPathsGLOBAL
-      : await getDocsPaths(branch)
+      : await getDocsPaths(branch, locale)
 
   const logger = getLogger('Guides')
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,8 +24,8 @@ const Home: Page<Props> = ({ branch }) => {
   return (
     <>
       <Head>
-        <title>VTEX Developers</title>
-        <meta property="og:title" content="VTEX Developers" key="title" />
+        <title>VTEX Help Center</title>
+        <meta property="og:title" content="VTEX Help Center" key="title" />
         <meta
           property="og:description"
           content="Build and extend your world of commerce with VTEX development platform and Core Commerce APIs."

--- a/src/pages/updates/announcements/[slug].tsx
+++ b/src/pages/updates/announcements/[slug].tsx
@@ -134,6 +134,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({
   params,
+  locale,
   preview,
   previewData,
 }) => {
@@ -146,7 +147,7 @@ export const getStaticProps: GetStaticProps = async ({
   const docsPaths =
     process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
       ? docsPathsGLOBAL
-      : await getDocsPaths(branch)
+      : await getDocsPaths(branch, locale)
 
   const path = docsPaths[slug]
   if (!path) {

--- a/src/utils/getDocsPaths.ts
+++ b/src/utils/getDocsPaths.ts
@@ -18,7 +18,7 @@ async function getGithubTree(org: string, repo: string, ref: string) {
 
 //https://api.github.com/repos/vtexdocs/devportal/commits?path=README.md
 
-export default async function getDocsPaths(branch = 'main') {
+export default async function getDocsPaths(branch = 'main', locale = '') {
   const repoTree = await getGithubTree(
     'vtexdocs',
     'help-center-content',
@@ -28,7 +28,7 @@ export default async function getDocsPaths(branch = 'main') {
   repoTree.tree.map((node: any) => {
     const path = node.path
     const re = /^(?<path>.+\/)*(?<filename>.+)\.(?<filetype>.+)$/
-    if (path.startsWith('docs')) {
+    if (path.startsWith(`docs/${locale}`)) {
       const match = path.match(re)
       const filename = match?.groups?.filename ? match?.groups?.filename : ''
       const filetype = match?.groups?.filetype ? match?.groups?.filetype : ''

--- a/src/utils/getReleasePaths.ts
+++ b/src/utils/getReleasePaths.ts
@@ -18,7 +18,7 @@ async function getGithubTree(org: string, repo: string, ref: string) {
 
 //https://api.github.com/repos/vtexdocs/devportal/commits?path=README.md
 
-export default async function getReleasePaths(branch = 'main') {
+export default async function getReleasePaths(branch = 'main', locale = '') {
   const repoTree = await getGithubTree(
     'vtexdocs',
     'help-center-content',
@@ -28,7 +28,7 @@ export default async function getReleasePaths(branch = 'main') {
   repoTree.tree.map((node: any) => {
     const path = node.path
     const re = /^(?<path>.+\/)*(?<filename>.+)\.(?<filetype>.+)$/
-    if (path.startsWith('docs/release-notes')) {
+    if (path.startsWith(`announcements/${locale}`)) {
       const match = path.match(re)
       const filename = match?.groups?.filename ? match?.groups?.filename : ''
       const filetype = match?.groups?.filetype ? match?.groups?.filetype : ''


### PR DESCRIPTION
#### What is the purpose of this pull request?

The `help-center-content` repository as organized as in the following:
- `docs`
    - `en`
    - `pt`
    - `es`
- `announcements`
    - `en`
    - `pt`
    - `es`

Considering this change, the `getDocsPaths` and `getReleasePaths`were updated to consider the locale folder.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
