### PR TITLE
feat(navigation-utils): enable navigation localization

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -5,39 +5,25 @@
       "slugPrefix": "docs/guides",
       "categories": [
         {
-          "name": "Getting Started",
           "slug": "getting-started-category",
+          "name": {
+            "en": "Getting Started",
+            "pt": "Primeiros Passos",
+            "es": "Primeros pasos"
+          },
           "origin": "",
           "type": "category",
           "children": [
             {
-              "name": "Introduction",
-              "slug": "getting-started",
+              "name": {
+                "en": "Catalog Overview",
+                "pt": "Catálogo - Visão Geral",
+                "es": "Catalogo - Vision General"
+              },
+              "slug": "catalog-overview",
               "origin": "",
               "type": "markdown",
-              "children": [
-                {
-                  "name": "Platform overview",
-                  "slug": "getting-started-platform-overview",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "List of REST APIs",
-                  "slug": "getting-started-list-of-rest-apis",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Making your first request",
-                  "slug": "making-your-first-request",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                }
-              ]
+              "children": []
             }
           ]
         }
@@ -89,19 +75,31 @@
       "slugPrefix": "updates/announcements",
       "categories": [
         {
-          "name": "2023",
+          "name": {
+            "en": "2023",
+            "pt": "2023",
+            "es": "2023"
+          },
           "slug": "2023-category",
           "origin": "",
           "type": "category",
           "children": [
             {
-              "name": "April",
+              "name": {
+                "en": "April",
+                "pt": "Abril",
+                "es": "Abril"
+              },
               "slug": "april-2023",
               "origin": "",
               "type": "category",
               "children": [
                 {
-                  "name": "Master Data v2 order entity will be deprecated",
+                  "name": {
+                    "en": "Master Data v2 order entity will be deprecated",
+                    "pt": "A entidade de pedidos do Master Data v2 será deprecada",
+                    "es": "Se descontinuará la entidad de pedidos de Master Data v2"
+                  },
                   "slug": "2023-11-04-master-data-v2-orders-entity-will-be-depreacted",
                   "origin": "",
                   "type": "markdown",
@@ -110,21 +108,33 @@
               ]
             },
             {
-              "name": "March",
+              "name": {
+                "en": "March",
+                "pt": "Março",
+                "es": "Marzo"
+              },
               "slug": "march-2023",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "February",
+              "name": {
+                "en": "February",
+                "pt": "Fevereiro",
+                "es": "Febrero"
+              },
               "slug": "february-2023",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "January",
+              "name": {
+                "en": "January",
+                "pt": "Janeiro",
+                "es": "Enero"
+              },
               "slug": "january-2023",
               "origin": "",
               "type": "category",
@@ -133,83 +143,131 @@
           ]
         },
         {
-          "name": "2022",
+          "name": {
+            "en": "2022",
+            "pt": "2022",
+            "es": "2022"
+          },
           "slug": "2022-category",
           "origin": "",
           "type": "category",
           "children": [
             {
-              "name": "November",
+              "name": {
+                "en": "November",
+                "pt": "Novembro",
+                "es": "Noviembre"
+              },
               "slug": "november-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "October",
+              "name": {
+                "en": "October",
+                "pt": "Outubro",
+                "es": "Octubre"
+              },
               "slug": "october-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "September",
+              "name": {
+                "en": "September",
+                "pt": "Setembro",
+                "es": "Septiembre"
+              },
               "slug": "september-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "August",
+              "name": {
+                "en": "August",
+                "pt": "Agosto",
+                "es": "Agosto"
+              },
               "slug": "august-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "July",
+              "name": {
+                "en": "July",
+                "pt": "Julho",
+                "es": "Julio"
+              },
               "slug": "july-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "June",
+              "name": {
+                "en": "June",
+                "pt": "Junho",
+                "es": "Junio"
+              },
               "slug": "june-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "May",
+              "name": {
+                "en": "May",
+                "pt": "Maio",
+                "es": "Marzo"
+              },
               "slug": "may-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "April",
+              "name": {
+                "en": "April",
+                "pt": "Abril",
+                "es": "Abril"
+              },
               "slug": "april-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "March",
+              "name": {
+                "en": "March",
+                "pt": "Março",
+                "es": "Marzo"
+              },
               "slug": "march-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "February",
+              "name": {
+                "en": "February",
+                "pt": "Fevereiro",
+                "es": "Febrero"
+              },
               "slug": "february-2022",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "January",
+              "name": {
+                "en": "January",
+                "pt": "Janeiro",
+                "es": "Enero"
+              },
               "slug": "january-2022",
               "origin": "",
               "type": "category",
@@ -218,90 +276,142 @@
           ]
         },
         {
-          "name": "2021",
+          "name": {
+            "en": "2021",
+            "pt": "2021",
+            "es": "2021"
+          },
           "slug": "2021-category",
           "origin": "",
           "type": "category",
           "children": [
             {
-              "name": "December",
+              "name": {
+                "en": "December",
+                "pt": "Dezembro",
+                "es": "Diciembre"
+              },
               "slug": "december-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "November",
+              "name": {
+                "en": "November",
+                "pt": "Novembro",
+                "es": "Noviembre"
+              },
               "slug": "november-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "October",
+              "name": {
+                "en": "October",
+                "pt": "Outubro",
+                "es": "Octubre"
+              },
               "slug": "october-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "September",
+              "name": {
+                "en": "September",
+                "pt": "Setembro",
+                "es": "Septiembre"
+              },
               "slug": "september-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "August",
+              "name": {
+                "en": "August",
+                "pt": "Agosto",
+                "es": "Agosto"
+              },
               "slug": "august-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "July",
+              "name": {
+                "en": "July",
+                "pt": "Julho",
+                "es": "Julio"
+              },
               "slug": "july-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "June",
+              "name": {
+                "en": "June",
+                "pt": "Junho",
+                "es": "Junio"
+              },
               "slug": "june-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "May",
+              "name": {
+                "en": "May",
+                "pt": "Maio",
+                "es": "Marzo"
+              },
               "slug": "may-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "April",
+              "name": {
+                "en": "April",
+                "pt": "Abril",
+                "es": "Abril"
+              },
               "slug": "april-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "March",
+              "name": {
+                "en": "March",
+                "pt": "Março",
+                "es": "Marzo"
+              },
               "slug": "march-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "February",
+              "name": {
+                "en": "February",
+                "pt": "Fevereiro",
+                "es": "Febrero"
+              },
               "slug": "february-2021",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "January",
+              "name": {
+                "en": "January",
+                "pt": "Janeiro",
+                "es": "Enero"
+              },
               "slug": "january-2021",
               "origin": "",
               "type": "category",
@@ -310,83 +420,131 @@
           ]
         },
         {
-          "name": "2020",
+          "name": {
+            "en": "2020",
+            "pt": "2020",
+            "es": "2020"
+          },
           "slug": "2020-category",
           "origin": "",
           "type": "category",
           "children": [
             {
-              "name": "December",
+              "name": {
+                "en": "December",
+                "pt": "Dezembro",
+                "es": "Diciembre"
+              },
               "slug": "december-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "November",
+              "name": {
+                "en": "November",
+                "pt": "Novembro",
+                "es": "Noviembre"
+              },
               "slug": "november-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "October",
+              "name": {
+                "en": "October",
+                "pt": "Outubro",
+                "es": "Octubre"
+              },
               "slug": "october-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "September",
+              "name": {
+                "en": "September",
+                "pt": "Setembro",
+                "es": "Septiembre"
+              },
               "slug": "september-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "August",
+              "name": {
+                "en": "August",
+                "pt": "Agosto",
+                "es": "Agosto"
+              },
               "slug": "august-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "July",
+              "name": {
+                "en": "July",
+                "pt": "Julho",
+                "es": "Julio"
+              },
               "slug": "july-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "June",
+              "name": {
+                "en": "June",
+                "pt": "Junho",
+                "es": "Junio"
+              },
               "slug": "june-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "May",
+              "name": {
+                "en": "May",
+                "pt": "Maio",
+                "es": "Marzo"
+              },
               "slug": "may-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "April",
+              "name": {
+                "en": "April",
+                "pt": "Abril",
+                "es": "Abril"
+              },
               "slug": "april-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "March",
+              "name": {
+                "en": "March",
+                "pt": "Março",
+                "es": "Marzo"
+              },
               "slug": "march-2020",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "February",
+              "name": {
+                "en": "February",
+                "pt": "Fevereiro",
+                "es": "Febrero"
+              },
               "slug": "february-2020",
               "origin": "",
               "type": "category",
@@ -395,41 +553,65 @@
           ]
         },
         {
-          "name": "2019",
+          "name": {
+            "en": "2019",
+            "pt": "2019",
+            "es": "2019"
+          },
           "slug": "2019-category",
           "origin": "",
           "type": "category",
           "children": [
             {
-              "name": "December",
+              "name": {
+                "en": "December",
+                "pt": "Dezembro",
+                "es": "Diciembre"
+              },
               "slug": "december-2019",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "November",
+              "name": {
+                "en": "November",
+                "pt": "Novembro",
+                "es": "Noviembre"
+              },
               "slug": "november-2019",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "October",
+              "name": {
+                "en": "October",
+                "pt": "Outubro",
+                "es": "Octubre"
+              },
               "slug": "october-2019",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "September",
+              "name": {
+                "en": "September",
+                "pt": "Setembro",
+                "es": "Septiembre"
+              },
               "slug": "september-2019",
               "origin": "",
               "type": "category",
               "children": []
             },
             {
-              "name": "August",
+              "name": {
+                "en": "August",
+                "pt": "Agosto",
+                "es": "Agosto"
+              },
               "slug": "august-2019",
               "origin": "",
               "type": "category",

--- a/src/components/sidebar-elements/index.tsx
+++ b/src/components/sidebar-elements/index.tsx
@@ -105,6 +105,9 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
     endpoint,
     children,
   }: SidebarElement) => {
+    const locale: string = useRouter().locale || 'en'
+    const localizedName: string =
+      typeof name === 'string' ? name : name[`${locale}`]
     const isExpandable = children.length > 0
     const pathSuffix = method ? `#${method.toLowerCase()}-${endpoint}` : ''
     const activeItem = method ? `${slug}${pathSuffix}` : slug
@@ -160,7 +163,7 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
                   method={method}
                 />
               )}
-              {name}
+              {localizedName}
             </Link>
           ) : checkDocumentationType(sidebarDataMaster, slug, 'link') ? (
             <Link href={slug} target="_blank" sx={styles.elementText}>
@@ -182,7 +185,7 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
                   method={method}
                 />
               )}
-              {name}
+              {localizedName}
             </Box>
           )}
         </Flex>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState, useContext } from 'react'
 import { Flex, Text, Box } from '@vtex/brand-ui'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { flattenJSON, getKeysByValue, getParents } from 'utils/navigation-utils'
 
 import styles from './styles'
 import type { SidebarSectionProps } from 'components/sidebar-section'
@@ -50,32 +49,8 @@ const Sidebar = ({
   const intl = useIntl()
 
   const router = useRouter()
-  const flattenedSidebar = flattenJSON(sidebarNavigation)
   let activeSlug = ''
-  let keyPath: string[] = []
-  const querySlug = router.query.slug
-  if (querySlug && router.pathname === '/docs/api-reference/[slug]') {
-    activeSlug = router.asPath.replace('/docs/api-reference/', '')
-    const docPath = activeSlug.split('/')
-    const endpoint = '/' + docPath.splice(1, docPath.length).join('/')
-    keyPath = getKeysByValue(flattenedSidebar, endpoint)
-    if (endpoint == '/') {
-      activeSlug = docPath[0].split('#')[0]
-    }
-    parentsArray.push(activeSlug)
-    keyPath.forEach((key: string) => {
-      if (key.length > 0)
-        getParents(
-          key,
-          'slug',
-          flattenedSidebar,
-          parentsArray,
-          activeSlug.split('#')[0]
-        )
-    })
-  } else {
-    activeSlug = parentsArray[parentsArray.length - 1]
-  }
+  activeSlug = parentsArray[parentsArray.length - 1]
 
   useEffect(() => {
     const timer = setTimeout(() => setExpandDelayStatus(false), 5000)

--- a/src/pages/docs/guides/[slug].tsx
+++ b/src/pages/docs/guides/[slug].tsx
@@ -42,7 +42,12 @@ import getFileContributors, {
 } from 'utils/getFileContributors'
 
 import { getLogger } from 'utils/logging/log-util'
-import { flattenJSON, getKeyByValue, getParents } from 'utils/navigation-utils'
+import {
+  flattenJSON,
+  getKeyByValue,
+  getParents,
+  localeType,
+} from 'utils/navigation-utils'
 
 const docsPathsGLOBAL = await getDocsPaths()
 
@@ -180,7 +185,9 @@ export const getStaticProps: GetStaticProps = async ({
       : 'main'
   const branch = preview ? previewBranch : 'main'
   const slug = params?.slug as string
-  const currentLocale = locale ? locale : 'en'
+  const currentLocale: localeType = locale
+    ? (locale as localeType)
+    : ('en' as localeType)
   const docsPaths =
     process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
       ? docsPathsGLOBAL
@@ -324,10 +331,22 @@ export const getStaticProps: GetStaticProps = async ({
     let sectionSelected = ''
     if (keyPath) {
       sectionSelected = flattenedSidebar[`${keyPath[0]}.documentation`]
-      getParents(keyPath, 'slug', flattenedSidebar, parentsArray)
+      getParents(keyPath, 'slug', flattenedSidebar, currentLocale, parentsArray)
       parentsArray.push(slug)
-      getParents(keyPath, 'name', flattenedSidebar, parentsArrayName)
-      getParents(keyPath, 'type', flattenedSidebar, parentsArrayType)
+      getParents(
+        keyPath,
+        'name',
+        flattenedSidebar,
+        currentLocale,
+        parentsArrayName
+      )
+      getParents(
+        keyPath,
+        'type',
+        flattenedSidebar,
+        currentLocale,
+        parentsArrayType
+      )
     }
 
     const breadcumbList: { slug: string; name: string; type: string }[] = []

--- a/src/pages/updates/announcements/[slug].tsx
+++ b/src/pages/updates/announcements/[slug].tsx
@@ -24,7 +24,12 @@ import OnThisPage from 'components/on-this-page'
 import TableOfContents from 'components/table-of-contents'
 
 import { removeHTML } from 'utils/string-utils'
-import { flattenJSON, getKeyByValue, getParents } from 'utils/navigation-utils'
+import {
+  flattenJSON,
+  getKeyByValue,
+  getParents,
+  localeType,
+} from 'utils/navigation-utils'
 import getNavigation from 'utils/getNavigation'
 import getGithubFile from 'utils/getGithubFile'
 import getDocsPaths from 'utils/getReleasePaths'
@@ -144,7 +149,9 @@ export const getStaticProps: GetStaticProps = async ({
       : 'main'
   const branch = preview ? previewBranch : 'main'
   const slug = params?.slug as string
-  const currentLocale = locale || 'en'
+  const currentLocale: localeType = locale
+    ? (locale as localeType)
+    : ('en' as localeType)
   const docsPaths =
     process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
       ? docsPathsGLOBAL
@@ -191,7 +198,7 @@ export const getStaticProps: GetStaticProps = async ({
     const keyPath = getKeyByValue(flattenedSidebar, slug)
     const parentsArray: string[] = []
     if (keyPath) {
-      getParents(keyPath, 'slug', flattenedSidebar, parentsArray)
+      getParents(keyPath, 'slug', flattenedSidebar, currentLocale, parentsArray)
       parentsArray.push(slug)
     }
     return {

--- a/src/utils/navigation-utils.ts
+++ b/src/utils/navigation-utils.ts
@@ -29,23 +29,28 @@ export const getKeysByValue = (
   return Object.keys(object).filter((key) => object[key] === value)
 }
 
+export type localeType = 'en' | 'pt' | 'es'
+
 export const getParents = (
   path: string,
   data: string,
   flattenedSidebar: { [x: string]: string },
+  locale: localeType = 'en',
   parentsArray: string[],
   parent?: string
 ) => {
   const pathParts = path?.split('children')
+  const desiredData = data === 'name' ? `${data}.${locale}` : data
   pathParts?.splice(-1)
   let prev = ''
   pathParts?.map((el) => {
     el = prev + el
     prev = el + 'children'
 
-    if (!parent || flattenedSidebar[`${el}${data}`].includes(parent)) {
-      parentsArray.push(flattenedSidebar[`${el}${data}`])
+    if (!parent || flattenedSidebar[`${el}${desiredData}`].includes(parent)) {
+      parentsArray.push(flattenedSidebar[`${el}${desiredData}`])
     }
   })
+  console.log(parentsArray)
   return parentsArray
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enable sidebar localization. 
The `name` field of the `navigation.json` file now has the following structure:
```
"name": {
            "en": "Getting Started",
            "pt": "Primeiros Passos",
            "es": "Primeros pasos"
          },
```

The `name` value corresponding to the current locale is used.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
