### PR TITLE
Feat/index specific pages

### DIFF
--- a/src/components/tutorial-markdown-render/index.tsx
+++ b/src/components/tutorial-markdown-render/index.tsx
@@ -55,6 +55,7 @@ const TutorialMarkdownRender = (props: Props) => {
     <>
       <Head>
         <title>{props.serialized.frontmatter?.title as string}</title>
+        <meta name="docsearch:slug" content={props.slug} />
         <meta name="docsearch:doctype" content="Tutorials & Solutions" />
         {props.serialized.frontmatter?.hidden && (
           <meta name="robots" content="noindex" />

--- a/src/pages/announcements/[slug].tsx
+++ b/src/pages/announcements/[slug].tsx
@@ -107,6 +107,7 @@ const AnnouncementPage: NextPage<Props> = ({
       <Head>
         <title>{serialized.frontmatter?.title as string}</title>
         <meta name="docsearch:doctype" content="announcements" />
+        <meta name="docsearch:slug" content={slug} />
       </Head>
       <DocumentContextProvider headings={headings}>
         <Flex sx={styles.innerContainer}>

--- a/src/pages/api/docs/[slug].ts
+++ b/src/pages/api/docs/[slug].ts
@@ -1,0 +1,20 @@
+// import { getAllDocsPaths } from 'utils/getDocsPaths'
+
+// const allPaths = await getAllDocsPaths()
+//eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function handler(req: any, res: any) {
+  const { slug, language, path }: { [key: string]: string } = req.query
+  const docCategory = path.split('/')[1]
+  let doc = ''
+
+  if (docCategory === 'tutorials') {
+    doc = 'docs/tutorial'
+  } else if (docCategory === 'tracks') {
+    doc = 'docs/tracks'
+  } else {
+    doc = docCategory
+  }
+
+  const url = `/${language ? `${language}/` : ''}${doc}/${slug}`
+  res.redirect(307, url)
+}

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -110,6 +110,7 @@ const TrackPage: NextPage<Props> = ({
       <Head>
         <title>{serialized.frontmatter?.title as string}</title>
         <meta name="docsearch:doctype" content="tracks" />
+        <meta name="docsearch:slug" content={slug} />
         {serialized.frontmatter?.hidden && (
           <meta name="robots" content="noindex" />
         )}

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -43,6 +43,7 @@ import DateText from 'components/date-text'
 const docsPathsGLOBAL = await getFaqPaths('faq')
 
 interface Props {
+  slug: string
   sectionSelected: string
   breadcrumbList: { slug: string; name: string; type: string }[]
   content: string
@@ -56,6 +57,7 @@ interface Props {
 const FaqPage: NextPage<Props> = ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   //@ts-ignore
+  slug,
   serialized,
   headingList,
   contributors,
@@ -85,6 +87,7 @@ const FaqPage: NextPage<Props> = ({
       <Head>
         <title>{serialized.frontmatter?.title as string}</title>
         <meta name="docsearch:doctype" content="Start here" />
+        <meta name="docsearch:slug" content={slug} />
         {serialized.frontmatter?.hidden && (
           <meta name="robots" content="noindex" />
         )}

--- a/src/pages/known-issues/[slug].tsx
+++ b/src/pages/known-issues/[slug].tsx
@@ -44,6 +44,7 @@ import DateText from 'components/date-text'
 const docsPathsGLOBAL = await getKnownIssuesPaths('known-issues')
 
 interface Props {
+  slug: string
   sectionSelected: string
   breadcrumbList: { slug: string; name: string; type: string }[]
   content: string
@@ -57,6 +58,7 @@ interface Props {
 const KnownIssuePage: NextPage<Props> = ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   //@ts-ignore
+  slug,
   serialized,
   headingList,
   contributors,
@@ -86,6 +88,7 @@ const KnownIssuePage: NextPage<Props> = ({
       <Head>
         <title>{serialized.frontmatter?.title as string}</title>
         <meta name="docsearch:doctype" content="Start here" />
+        <meta name="docsearch:slug" content={slug} />
         {serialized.frontmatter?.hidden && (
           <meta name="robots" content="noindex" />
         )}


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Index pages slug
- Add route that allows scrape specific documents using the doc path in the content repository ([help-center-content](https://github.com/vtexdocs/help-center-content))

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
