### PR TITLE
feat: display time to read article only if higher than 5 minutes

### DIFF
--- a/src/components/TimeToRead/index.tsx
+++ b/src/components/TimeToRead/index.tsx
@@ -1,0 +1,33 @@
+import { Text } from '@vtex/brand-ui'
+import { useIntl } from 'react-intl'
+
+import readingTime from 'styles/documentation-page'
+
+interface props {
+  minutes: string
+}
+
+const TimeToRead = ({ minutes }: props) => {
+  function shouldTimeDisplay(minutes: string): boolean {
+    return parseInt(minutes) >= 5
+  }
+
+  const intl = useIntl()
+
+  if (shouldTimeDisplay(minutes)) {
+    return (
+      <Text sx={readingTime}>
+        {intl.formatMessage(
+          {
+            id: 'documentation_reading_time.text',
+            defaultMessage: '',
+          },
+          { minutes: minutes }
+        )}
+      </Text>
+    )
+  }
+  return null
+}
+
+export default TimeToRead

--- a/src/components/TimeToRead/styles.ts
+++ b/src/components/TimeToRead/styles.ts
@@ -1,0 +1,11 @@
+import { SxStyleProp } from '@vtex/brand-ui'
+
+const readingTime: SxStyleProp = {
+  color: '#A1AAB7',
+  fontSize: '16px',
+  lineHeight: '18px',
+}
+
+export default {
+  readingTime,
+}

--- a/src/components/tutorial-markdown-render/index.tsx
+++ b/src/components/tutorial-markdown-render/index.tsx
@@ -16,6 +16,7 @@ import ArticlePagination from 'components/article-pagination'
 import Contributors from 'components/contributors'
 import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { ContributorsType } from 'utils/getFileContributors'
+import TimeToRead from 'components/TimeToRead'
 
 interface Props {
   content: string
@@ -92,17 +93,11 @@ const TutorialMarkdownRender = (props: Props) => {
                     {props.serialized.frontmatter?.excerpt}
                   </Text>
                 </header>
-                <Text sx={styles.readingTime}>
-                  {intl.formatMessage(
-                    {
-                      id: 'documentation_reading_time.text',
-                      defaultMessage: '',
-                    },
-                    {
-                      minutes: props.serialized.frontmatter?.readingTime,
-                    }
-                  )}
-                </Text>
+                {props.serialized.frontmatter?.readingTime && (
+                  <TimeToRead
+                    minutes={props.serialized.frontmatter.readingTime}
+                  />
+                )}
                 <MarkdownRenderer serialized={props.serialized} />
               </article>
             </Box>

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -45,8 +45,9 @@ import {
 } from 'utils/navigation-utils'
 import { MarkdownRenderer } from '@vtexdocs/components'
 // import { ParsedUrlQuery } from 'querystring'
-import { useIntl } from 'react-intl'
+
 import { remarkReadingTime } from 'utils/remark_plugins/remarkReadingTime'
+import TimeToRead from 'components/TimeToRead'
 
 const docsPathsGLOBAL = await getTracksPaths('tracks')
 
@@ -95,7 +96,6 @@ const TrackPage: NextPage<Props> = ({
 }) => {
   const [headings, setHeadings] = useState<Item[]>([])
   const { setBranchPreview } = useContext(PreviewContext)
-  const intl = useIntl()
   setBranchPreview(branch)
   const { setActiveSidebarElement } = useContext(LibraryContext)
   const articleRef = useRef<HTMLElement>(null)
@@ -131,15 +131,11 @@ const TrackPage: NextPage<Props> = ({
                     <Text sx={styles.documentationTitle} className="title">
                       {serialized.frontmatter?.title}
                     </Text>
-                    <Text sx={styles.readingTime}>
-                      {intl.formatMessage(
-                        {
-                          id: 'documentation_reading_time.text',
-                          defaultMessage: '',
-                        },
-                        { minutes: serialized.frontmatter?.readingTime }
-                      )}
-                    </Text>
+                    {serialized.frontmatter?.readingTime && (
+                      <TimeToRead
+                        minutes={serialized.frontmatter.readingTime}
+                      />
+                    )}
                   </Flex>
                 </header>
                 <MarkdownRenderer serialized={serialized} />

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -19,6 +19,7 @@ import Contributors from 'components/contributors'
 import OnThisPage from 'components/on-this-page'
 import { Item, TableOfContents } from '@vtexdocs/components'
 import Breadcrumb from 'components/breadcrumb'
+import TimeToRead from 'components/TimeToRead'
 
 import getHeadings from 'utils/getHeadings'
 import getNavigation from 'utils/getNavigation'
@@ -34,7 +35,6 @@ import { getLogger } from 'utils/logging/log-util'
 import { localeType } from 'utils/navigation-utils'
 import { MarkdownRenderer } from '@vtexdocs/components'
 // import { ParsedUrlQuery } from 'querystring'
-import { useIntl } from 'react-intl'
 import { remarkReadingTime } from 'utils/remark_plugins/remarkReadingTime'
 import { getDocsPaths as getFaqPaths } from 'utils/getDocsPaths'
 import { getMessages } from 'utils/get-messages'
@@ -64,7 +64,6 @@ const FaqPage: NextPage<Props> = ({
 }) => {
   const [headings, setHeadings] = useState<Item[]>([])
   const { setBranchPreview } = useContext(PreviewContext)
-  const intl = useIntl()
   setBranchPreview(branch)
   const articleRef = useRef<HTMLElement>(null)
 
@@ -106,15 +105,11 @@ const FaqPage: NextPage<Props> = ({
                     <Text sx={styles.documentationTitle} className="title">
                       {serialized.frontmatter?.title}
                     </Text>
-                    <Text sx={styles.readingTime}>
-                      {intl.formatMessage(
-                        {
-                          id: 'documentation_reading_time.text',
-                          defaultMessage: '',
-                        },
-                        { minutes: serialized.frontmatter?.readingTime }
-                      )}
-                    </Text>
+                    {serialized.frontmatter?.readingTime && (
+                      <TimeToRead
+                        minutes={serialized.frontmatter.readingTime}
+                      />
+                    )}
                     {createdAtDate && updatedAtDate && (
                       <DateText
                         createdAt={createdAtDate}

--- a/src/pages/known-issues/[slug].tsx
+++ b/src/pages/known-issues/[slug].tsx
@@ -82,8 +82,6 @@ const KnownIssuePage: NextPage<Props> = ({
     ? new Date(serialized.frontmatter?.updatedAt)
     : undefined
 
-  console.log(serialized.frontmatter?.readingTime)
-
   return (
     <>
       <Head>

--- a/src/pages/known-issues/[slug].tsx
+++ b/src/pages/known-issues/[slug].tsx
@@ -19,6 +19,7 @@ import Contributors from 'components/contributors'
 import OnThisPage from 'components/on-this-page'
 import { Item, TableOfContents } from '@vtexdocs/components'
 import Breadcrumb from 'components/breadcrumb'
+import TimeToRead from 'components/TimeToRead'
 
 import getHeadings from 'utils/getHeadings'
 import getNavigation from 'utils/getNavigation'
@@ -34,7 +35,7 @@ import { getLogger } from 'utils/logging/log-util'
 import { localeType } from 'utils/navigation-utils'
 import { MarkdownRenderer } from '@vtexdocs/components'
 // import { ParsedUrlQuery } from 'querystring'
-import { useIntl } from 'react-intl'
+
 import { remarkReadingTime } from 'utils/remark_plugins/remarkReadingTime'
 import { getDocsPaths as getKnownIssuesPaths } from 'utils/getDocsPaths'
 import { getMessages } from 'utils/get-messages'
@@ -65,7 +66,7 @@ const KnownIssuePage: NextPage<Props> = ({
 }) => {
   const [headings, setHeadings] = useState<Item[]>([])
   const { setBranchPreview } = useContext(PreviewContext)
-  const intl = useIntl()
+
   setBranchPreview(branch)
   const articleRef = useRef<HTMLElement>(null)
 
@@ -80,6 +81,8 @@ const KnownIssuePage: NextPage<Props> = ({
   const updatedAtDate = serialized.frontmatter?.updatedAt
     ? new Date(serialized.frontmatter?.updatedAt)
     : undefined
+
+  console.log(serialized.frontmatter?.readingTime)
 
   return (
     <>
@@ -107,15 +110,11 @@ const KnownIssuePage: NextPage<Props> = ({
                     <Text sx={styles.documentationTitle} className="title">
                       {serialized.frontmatter?.title}
                     </Text>
-                    <Text sx={styles.readingTime}>
-                      {intl.formatMessage(
-                        {
-                          id: 'documentation_reading_time.text',
-                          defaultMessage: '',
-                        },
-                        { minutes: serialized.frontmatter?.readingTime }
-                      )}
-                    </Text>
+                    {serialized.frontmatter?.readingTime && (
+                      <TimeToRead
+                        minutes={serialized.frontmatter.readingTime}
+                      />
+                    )}
                   </Flex>
                   <Box sx={styles.divider}></Box>
                   <Flex sx={styles.detailedInfo}>

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -114,12 +114,6 @@ const divider: SxStyleProp = {
   borderBottom: '1px solid #E7E9EE',
 }
 
-const readingTime: SxStyleProp = {
-  color: '#A1AAB7',
-  fontSize: '16px',
-  lineHeight: '18px',
-}
-
 const flexContainer: SxStyleProp = {
   flexWrap: 'wrap',
   flexDirection: 'column',
@@ -183,7 +177,6 @@ export default {
   documentationExcerpt,
   innerContainer,
   divider,
-  readingTime,
   flexContainer,
   detailedInfo,
   id,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change the way the time to read docs pages work, only displaying when the estimated time is higher or equal to 5 minutes

#### What problem is this solving?

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
