### PR TITLE
Fix doubled first words in track articles' titles

### DIFF
--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -433,12 +433,6 @@ export const getStaticProps: GetStaticProps = async ({
         parentsArrayType
       )
       parentsArrayType.push(docsListType[indexOfSlug])
-
-      if (serialized.frontmatter) {
-        serialized.frontmatter.title = `${
-          docsListName[indexOfSlug][currentLocale].split(' ')[0]
-        } ${serialized.frontmatter.title}`
-      }
     }
 
     const breadcrumbList: { slug: string; name: string; type: string }[] = []


### PR DESCRIPTION
Since we decided not to use reference numbers in track articles page titles, this part of the code was generating a bug, described in issue 86. So this PR removes it.

#### How should this be manually tested?

I tested this locally, and it worked fine.

1. Run the portal locally.
2. Access this [article](http://localhost:3000/pt/docs/tracks/integration-overview).
3. See if the first word in the page header is doubled.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
