### PR TITLE
fix: word breaking and width off tables columns

### DIFF
--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -52,7 +52,7 @@ const articleBox: SxStyleProp = {
   },
   strong: {
     fontWeight: '600',
-    overflowWrap: 'anywhere',
+    overflowWrap: 'break-word',
   },
   hr: {
     border: '0.5px solid #E7E9EE',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -69,6 +69,7 @@ table th {
   font-size: 0.875em;
   border: 1px solid #e7e9ef;
   padding: 0.5em;
+  min-width: 60px;
 }
 
 table tbody tr:nth-of-type(even) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make tables columns have a minimum width

#### What problem is this solving?

Tables columns headers being too small depending on device

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
