### PR TITLE
Fix docs paths validation 

### DIFF
--- a/src/utils/getDocsPaths.ts
+++ b/src/utils/getDocsPaths.ts
@@ -62,17 +62,20 @@ export async function getDocsPaths(
     const path = node.path
     const re =
       /^(?<path>.+\/)*(?<locale>pt|es|en+)\/(?<localeDir>.+\/)*(?<filename>.+)\.(?<filetype>.+)$/
-    if (path.startsWith(`docs/${category}`)) {
+    if (path.startsWith(`docs/`)) {
       const match = path.match(re)
-      const filename = match?.groups?.filename ? match?.groups?.filename : ''
-      const filetype = match?.groups?.filetype ? match?.groups?.filetype : ''
-      const fileLocale = match?.groups?.locale ? match?.groups?.locale : ''
-      if (filetype === 'md' || filetype === 'mdx') {
-        if (!docsPaths[filename]) docsPaths[filename] = []
-        docsPaths[filename].push({
-          locale: fileLocale,
-          path,
-        })
+      const localeDir = match?.groups?.localeDir ? match?.groups?.localeDir : ''
+      if (localeDir.startsWith(category)) {
+        const filename = match?.groups?.filename ? match?.groups?.filename : ''
+        const filetype = match?.groups?.filetype ? match?.groups?.filetype : ''
+        const fileLocale = match?.groups?.locale ? match?.groups?.locale : ''
+        if (filetype === 'md' || filetype === 'mdx') {
+          if (!docsPaths[filename]) docsPaths[filename] = []
+          docsPaths[filename].push({
+            locale: fileLocale,
+            path,
+          })
+        }
       }
     }
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "target": "es2017",
+    "target": "es2018",
     "allowJs": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
…to match new folder structure

#### What problem is this solving?

This `help-center-content` [PR](https://github.com/vtexdocs/help-center-content/pull/29) changes the repository's folder structure to match the portal's content architecture. This means we need to change the way we get/validate docs paths from github.

#### How should this be manually tested?

1. Run the portal locally from this branch, using `/api/preview?branch=edit-folder-structure`.
2. Try to access different articles.