### PR TITLE
Fix content preview branch selection on KI and FAQ pages

### DIFF
--- a/src/pages/faq/index.tsx
+++ b/src/pages/faq/index.tsx
@@ -30,8 +30,6 @@ interface Props {
   totalPages: number
 }
 
-const docsPathsGLOBAL = await getFaqPaths('faq')
-
 const FaqPage: NextPage<Props> = ({ faqData, branch }) => {
   const intl = useIntl()
   const { setBranchPreview } = useContext(PreviewContext)
@@ -147,6 +145,7 @@ export const getStaticProps: GetStaticProps = async ({
       ? JSON.parse(JSON.stringify(previewData)).branch
       : 'main'
   const branch = preview ? previewBranch : 'main'
+  const docsPathsGLOBAL = await getFaqPaths('faq', branch)
   const logger = getLogger('FAQ')
   const currentLocale: localeType = locale
     ? (locale as localeType)

--- a/src/pages/known-issues/index.tsx
+++ b/src/pages/known-issues/index.tsx
@@ -38,8 +38,6 @@ interface Props {
   totalPages: number
 }
 
-const docsPathsGLOBAL = await getKnownIssuesPaths('known-issues')
-
 const KnownIssuesPage: NextPage<Props> = ({ knownIssuesData, branch }) => {
   const intl = useIntl()
   const { setBranchPreview } = useContext(PreviewContext)
@@ -169,6 +167,7 @@ export const getStaticProps: GetStaticProps = async ({
       ? JSON.parse(JSON.stringify(previewData)).branch
       : 'main'
   const branch = preview ? previewBranch : 'main'
+  const docsPathsGLOBAL = await getKnownIssuesPaths('known-issues')
   const logger = getLogger('Known Issues')
   const currentLocale: localeType = locale
     ? (locale as localeType)


### PR DESCRIPTION
#### What is the purpose of this pull request?

It was not possible to preview content in the FAQ and KI pages before because the fetching of the docs paths occurred outside of getStaticProps. This PR fixes it.

Learn more on this problem and how to test in [issue 101](https://github.com/vtexdocs/helpcenter/issues/101).