### PR TITLE
fix: breadcrumbs rendering link instead of text

### DIFF
--- a/src/components/breadcrumb/index.tsx
+++ b/src/components/breadcrumb/index.tsx
@@ -9,29 +9,20 @@ interface Props {
 const Breadcrumb = ({ breadcrumbList }: Props) => {
   return (
     <Flex sx={styles.breadcrumb}>
-      {breadcrumbList.map((item, idx) =>
-        item.type === 'category' ? (
-          <>
-            <Text>{item.name}</Text>
-            {idx < breadcrumbList.length - 1 ? (
-              <IconCaret direction="right" size={16} />
-            ) : (
-              ''
-            )}
-          </>
-        ) : (
-          <>
+      {breadcrumbList.map((item, idx) => (
+        <>
+          {item.type === 'markdown' ? (
             <Link sx={styles.breadcrumbItem} href={item.slug}>
               {item.name}
             </Link>
-            {idx < breadcrumbList.length - 1 ? (
-              <IconCaret direction="right" size={16} />
-            ) : (
-              ''
-            )}
-          </>
-        )
-      )}
+          ) : (
+            <Text>{item.name}</Text>
+          )}
+          {idx < breadcrumbList.length - 1 ? (
+            <IconCaret direction="right" size={16} />
+          ) : null}
+        </>
+      ))}
     </Flex>
   )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixing breadcrumbs from some articles having a link to a unexisting page

#### What problem is this solving?

Breadcrumbs having links to pages that do not exist yet

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
