### PR TITLE
Fix/breadcrumbs links without locale

### DIFF
--- a/src/components/breadcrumb/index.tsx
+++ b/src/components/breadcrumb/index.tsx
@@ -1,4 +1,5 @@
-import { Link, Flex, IconCaret, Text } from '@vtex/brand-ui'
+import { Flex, IconCaret, Text } from '@vtex/brand-ui'
+import Link from 'next/link'
 
 import styles from './styles'
 
@@ -12,8 +13,8 @@ const Breadcrumb = ({ breadcrumbList }: Props) => {
       {breadcrumbList.map((item, idx) => (
         <>
           {item.type === 'markdown' ? (
-            <Link sx={styles.breadcrumbItem} href={item.slug}>
-              {item.name}
+            <Link href={item.slug}>
+              <Text sx={styles.breadcrumbItem}>{item.name}</Text>
             </Link>
           ) : (
             <Text>{item.name}</Text>

--- a/src/components/breadcrumb/styles.ts
+++ b/src/components/breadcrumb/styles.ts
@@ -9,9 +9,9 @@ const breadcrumb: SxStyleProp = {
 }
 
 const breadcrumbItem: SxStyleProp = {
-  color: '#6b7785 !important',
+  color: '#6b7785',
   ':hover': {
-    color: '#5E6E84 !important',
+    color: '#5E6E84',
   },
 }
 

--- a/src/pages/announcements/[slug].tsx
+++ b/src/pages/announcements/[slug].tsx
@@ -91,7 +91,7 @@ const AnnouncementPage: NextPage<Props> = ({
   }, [])
 
   const breadcrumb = {
-    slug: '/announcements',
+    slug: `/announcements`,
     name: intl.formatMessage({ id: 'announcements_page.title' }),
     type: 'category',
   }

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -412,7 +412,8 @@ export const getServerSideProps: GetServerSideProps = async ({
         parentsArray,
         parentsArrayName,
         parentsArrayType,
-        'tracks'
+        'tracks',
+        locale
       )
 
     return {

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -408,7 +408,12 @@ export const getServerSideProps: GetServerSideProps = async ({
     }
 
     const breadcrumbList: { slug: string; name: string; type: string }[] =
-      getBreadcrumbsList(parentsArray, parentsArrayName, parentsArrayType)
+      getBreadcrumbsList(
+        parentsArray,
+        parentsArrayName,
+        parentsArrayType,
+        'tracks'
+      )
 
     return {
       props: {

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -49,6 +49,7 @@ import { remarkReadingTime } from 'utils/remark_plugins/remarkReadingTime'
 
 import theme from 'styles/code-hike-theme'
 import TimeToRead from 'components/TimeToRead'
+import { getBreadcrumbsList } from 'utils/getBreadcrumbsList'
 
 const docsPathsGLOBAL = await getTracksPaths('tracks')
 
@@ -406,14 +407,8 @@ export const getServerSideProps: GetServerSideProps = async ({
       }
     }
 
-    const breadcrumbList: { slug: string; name: string; type: string }[] = []
-    parentsArrayName.forEach((_el: string, idx: number) => {
-      breadcrumbList.push({
-        slug: `/${locale}/docs/tracks/${parentsArray[idx]}`,
-        name: parentsArrayName[idx],
-        type: parentsArrayType[idx] || 'defaultType',
-      })
-    })
+    const breadcrumbList: { slug: string; name: string; type: string }[] =
+      getBreadcrumbsList(parentsArray, parentsArrayName, parentsArrayType)
 
     return {
       props: {

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -412,8 +412,7 @@ export const getServerSideProps: GetServerSideProps = async ({
         parentsArray,
         parentsArrayName,
         parentsArrayType,
-        'tracks',
-        locale
+        'tracks'
       )
 
     return {

--- a/src/pages/docs/tutorial/[slug].tsx
+++ b/src/pages/docs/tutorial/[slug].tsx
@@ -39,6 +39,7 @@ import { remarkCodeHike } from '@code-hike/mdx'
 import TutorialIndexing from 'components/tutorial-index'
 import TutorialMarkdownRender from 'components/tutorial-markdown-render'
 import theme from 'styles/code-hike-theme'
+import { getBreadcrumbsList } from 'utils/getBreadcrumbsList'
 
 // import { ParsedUrlQuery } from 'querystring'
 
@@ -223,14 +224,8 @@ export const getServerSideProps: GetServerSideProps = async ({
   const sectionSelected = flattenedSidebar[`${keyPath[0]}.documentation`]
   console.log('TUTORIAL', sectionSelected)
 
-  const breadcrumbList: { slug: string; name: string; type: string }[] = []
-  parentsArrayName.forEach((_el: string, idx: number) => {
-    breadcrumbList.push({
-      slug: `/${locale}/docs/tutorial/${parentsArray[idx]}`,
-      name: parentsArrayName[idx],
-      type: parentsArrayType[idx],
-    })
-  })
+  const breadcrumbList: { slug: string; name: string; type: string }[] =
+    getBreadcrumbsList(parentsArray, parentsArrayName, parentsArrayType)
 
   if (type === 'tutorial-category') {
     const childrenArrayName: string[] = []

--- a/src/pages/docs/tutorial/[slug].tsx
+++ b/src/pages/docs/tutorial/[slug].tsx
@@ -225,7 +225,12 @@ export const getServerSideProps: GetServerSideProps = async ({
   console.log('TUTORIAL', sectionSelected)
 
   const breadcrumbList: { slug: string; name: string; type: string }[] =
-    getBreadcrumbsList(parentsArray, parentsArrayName, parentsArrayType)
+    getBreadcrumbsList(
+      parentsArray,
+      parentsArrayName,
+      parentsArrayType,
+      'tutorial'
+    )
 
   if (type === 'tutorial-category') {
     const childrenArrayName: string[] = []

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -265,7 +265,7 @@ export const getStaticProps: GetStaticProps = async ({
       {
         slug,
         name: serialized?.frontmatter?.title ?? '',
-        type: '',
+        type: 'markdown',
       },
     ]
 

--- a/src/pages/known-issues/[slug].tsx
+++ b/src/pages/known-issues/[slug].tsx
@@ -274,7 +274,7 @@ export const getStaticProps: GetStaticProps = async ({
       {
         slug,
         name: serialized?.frontmatter?.title ?? '',
-        type: '',
+        type: 'markdown',
       },
     ]
 

--- a/src/utils/getBreadcrumbsList.ts
+++ b/src/utils/getBreadcrumbsList.ts
@@ -1,12 +1,13 @@
 export function getBreadcrumbsList(
   parents: string[],
   parentsNames: string[],
-  parentsTypes: string[]
+  parentsTypes: string[],
+  docsType: 'tutorial' | 'tracks'
 ) {
   const breadcrumbs: { slug: string; name: string; type: string }[] = []
   parentsNames.forEach((_el: string, idx: number) => {
     breadcrumbs.push({
-      slug: `/docs/tutorial/${parents[idx]}`,
+      slug: `/docs/${docsType}/${parents[idx]}`,
       name: parentsNames[idx],
       type: parentsTypes[idx],
     })

--- a/src/utils/getBreadcrumbsList.ts
+++ b/src/utils/getBreadcrumbsList.ts
@@ -2,13 +2,12 @@ export function getBreadcrumbsList(
   parents: string[],
   parentsNames: string[],
   parentsTypes: string[],
-  docsType: 'tutorial' | 'tracks',
-  locale?: string
+  docsType: 'tutorial' | 'tracks'
 ) {
   const breadcrumbs: { slug: string; name: string; type: string }[] = []
   parentsNames.forEach((_el: string, idx: number) => {
     breadcrumbs.push({
-      slug: `${locale}/docs/${docsType}/${parents[idx]}`,
+      slug: `/docs/${docsType}/${parents[idx]}`,
       name: parentsNames[idx],
       type: parentsTypes[idx] || 'defaultType',
     })

--- a/src/utils/getBreadcrumbsList.ts
+++ b/src/utils/getBreadcrumbsList.ts
@@ -1,0 +1,15 @@
+export function getBreadcrumbsList(
+  parents: string[],
+  parentsNames: string[],
+  parentsTypes: string[]
+) {
+  const breadcrumbs: { slug: string; name: string; type: string }[] = []
+  parentsNames.forEach((_el: string, idx: number) => {
+    breadcrumbs.push({
+      slug: `/docs/tutorial/${parents[idx]}`,
+      name: parentsNames[idx],
+      type: parentsTypes[idx],
+    })
+  })
+  return breadcrumbs
+}

--- a/src/utils/getBreadcrumbsList.ts
+++ b/src/utils/getBreadcrumbsList.ts
@@ -2,14 +2,15 @@ export function getBreadcrumbsList(
   parents: string[],
   parentsNames: string[],
   parentsTypes: string[],
-  docsType: 'tutorial' | 'tracks'
+  docsType: 'tutorial' | 'tracks',
+  locale?: string
 ) {
   const breadcrumbs: { slug: string; name: string; type: string }[] = []
   parentsNames.forEach((_el: string, idx: number) => {
     breadcrumbs.push({
-      slug: `/docs/${docsType}/${parents[idx]}`,
+      slug: `${locale}/docs/${docsType}/${parents[idx]}`,
       name: parentsNames[idx],
-      type: parentsTypes[idx],
+      type: parentsTypes[idx] || 'defaultType',
     })
   })
   return breadcrumbs


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix breadcrumbs links without locale

#### What problem is this solving?

Breadcrumbs links do not maintain the chosen locale, so accessing a article might change the portal locale

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
