### PR TITLE
Fix/ki internal reference

### DIFF
--- a/src/pages/known-issues/[slug].tsx
+++ b/src/pages/known-issues/[slug].tsx
@@ -119,7 +119,9 @@ const KnownIssuePage: NextPage<Props> = ({
                   <Box sx={styles.divider}></Box>
                   <Flex sx={styles.detailedInfo}>
                     <Flex sx={styles.id}>
-                      <Text>ID: {serialized.frontmatter?.id}</Text>
+                      <Text>
+                        ID: {serialized.frontmatter?.internalReference}
+                      </Text>
                       <Tag>{serialized.frontmatter?.kiStatus}</Tag>
                     </Flex>
                     {createdAtDate && updatedAtDate && (

--- a/src/pages/known-issues/index.tsx
+++ b/src/pages/known-issues/index.tsx
@@ -238,7 +238,7 @@ export const getStaticProps: GetStaticProps = async ({
 
           if (frontmatter && frontmatter.tag && frontmatter.kiStatus)
             knownIssuesData.push({
-              id: frontmatter.id,
+              id: frontmatter.internalReference,
               title: frontmatter.title,
               module: frontmatter.tag,
               slug: data.slug,


### PR DESCRIPTION
Fixes #121 

With this change, KI pages nad KI list pages will display the zendesk ID instead of the Contentful entry ID. 