### PR TITLE
feat: hide unpublished content

### DIFF
--- a/src/components/known-issue-card/index.tsx
+++ b/src/components/known-issue-card/index.tsx
@@ -11,7 +11,7 @@ const KnownIssueCard = ({
   title,
   id,
   module,
-  status,
+  kiStatus,
   slug,
   createdAt,
   updatedAt,
@@ -24,9 +24,9 @@ const KnownIssueCard = ({
     <Link href={`known-issues/${slug}`}>
       <Flex sx={styles.container}>
         <Flex sx={styles.topContainer}>
-          <Tag color={status}>
+          <Tag color={kiStatus}>
             {intl.formatMessage({
-              id: `known_issues_filter_status.${status.toLowerCase()}`,
+              id: `known_issues_filter_status.${kiStatus.toLowerCase()}`,
             })}
           </Tag>
           <Text sx={styles.knownIssueModule} className="module">

--- a/src/pages/announcements/index.tsx
+++ b/src/pages/announcements/index.tsx
@@ -43,9 +43,11 @@ const AnnouncementsPage: NextPage<Props> = ({ announcementsData, branch }) => {
   const [sortByValue, setSortByValue] = useState<SortByType>('newest')
 
   const filteredResult = useMemo(() => {
-    const data = announcementsData.filter((announcement) =>
-      announcement.title?.toLowerCase().includes(searchTerm.toLowerCase())
-    )
+    const data = announcementsData
+      .filter((announcement) => announcement.status === 'PUBLISHED')
+      .filter((announcement) =>
+        announcement.title?.toLowerCase().includes(searchTerm.toLowerCase())
+      )
 
     data.sort((a, b) => {
       const dateA =
@@ -215,6 +217,7 @@ export const getStaticProps: GetStaticProps = async ({
               url: `announcements/${data.slug}`,
               createdAt: String(frontmatter.createdAt),
               updatedAt: String(frontmatter.updatedAt),
+              status: frontmatter.status ?? null,
             })
         } catch (error) {
           logger.error(`${error}`)

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -294,6 +294,13 @@ export const getServerSideProps: GetServerSideProps = async ({
       },
     })
 
+    // Check the frontmatter status
+    if (serialized.frontmatter?.status !== 'PUBLISHED') {
+      return {
+        notFound: true,
+      }
+    }
+
     const sidebarfallback = await getNavigation()
     serialized = JSON.parse(JSON.stringify(serialized))
 

--- a/src/pages/docs/tutorial/[slug].tsx
+++ b/src/pages/docs/tutorial/[slug].tsx
@@ -385,6 +385,13 @@ export const getServerSideProps: GetServerSideProps = async ({
       },
     })
 
+    // Check the frontmatter status
+    if (serialized.frontmatter?.status !== 'PUBLISHED') {
+      return {
+        notFound: true,
+      }
+    }
+
     serialized = JSON.parse(JSON.stringify(serialized))
 
     logger.info(`Processing ${slug}`)

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -184,6 +184,19 @@ export const getStaticProps: GetStaticProps = async ({
       .then((res) => res.text())
       .catch((err) => console.log(err))) || ''
 
+  // Serialize content and parse frontmatter
+  const serialized = await serialize(documentationContent, {
+    parseFrontmatter: true,
+  })
+
+  // Check if status is "PUBLISHED"
+  const isPublished = serialized?.frontmatter?.status === 'PUBLISHED'
+  if (!isPublished) {
+    return {
+      notFound: true,
+    }
+  }
+
   const contributors =
     (await fetch(
       `https://github.com/vtexdocs/help-center-content/file-contributors/${branch}/${path}`,

--- a/src/pages/faq/index.tsx
+++ b/src/pages/faq/index.tsx
@@ -49,15 +49,17 @@ const FaqPage: NextPage<Props> = ({ faqData, branch }) => {
   )
 
   const filteredResult = useMemo(() => {
-    const data = faqData.filter((question) => {
-      const hasFilter: boolean =
-        filters.length === 0 || filters.includes(question.productTeam)
-      const hasSearch: boolean = question.title
-        .toLowerCase()
-        .includes(search.toLowerCase())
+    const data = faqData
+      .filter((question) => question.status === 'PUBLISHED')
+      .filter((question) => {
+        const hasFilter: boolean =
+          filters.length === 0 || filters.includes(question.productTeam)
+        const hasSearch: boolean = question.title
+          .toLowerCase()
+          .includes(search.toLowerCase())
 
-      return hasFilter && hasSearch
-    })
+        return hasFilter && hasSearch
+      })
 
     data.sort((a, b) => {
       const dateA =
@@ -266,6 +268,7 @@ export const getStaticProps: GetStaticProps = async ({
               createdAt: String(frontmatter.createdAt),
               updatedAt: String(frontmatter.updatedAt),
               productTeam: frontmatter.productTeam,
+              status: frontmatter.status,
             })
         } catch (error) {
           logger.error(`${error}`)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -127,6 +127,7 @@ export const getStaticProps: GetStaticProps = async ({
               url: `announcements/${data.slug}`,
               createdAt: String(frontmatter.createdAt),
               updatedAt: String(frontmatter.updatedAt),
+              status: frontmatter.status,
             })
           }
         } catch (error) {

--- a/src/pages/known-issues/[slug].tsx
+++ b/src/pages/known-issues/[slug].tsx
@@ -195,6 +195,19 @@ export const getStaticProps: GetStaticProps = async ({
       .then((res) => res.text())
       .catch((err) => console.log(err))) || ''
 
+  // Serialize content and parse frontmatter
+  const serialized = await serialize(documentationContent, {
+    parseFrontmatter: true,
+  })
+
+  // Check if status is "PUBLISHED"
+  const isPublished = serialized?.frontmatter?.status === 'PUBLISHED'
+  if (!isPublished) {
+    return {
+      notFound: true,
+    }
+  }
+
   const contributors =
     (await fetch(
       `https://github.com/vtexdocs/help-center-content/file-contributors/${branch}/${path}`,

--- a/src/pages/known-issues/index.tsx
+++ b/src/pages/known-issues/index.tsx
@@ -48,25 +48,27 @@ const KnownIssuesPage: NextPage<Props> = ({ knownIssuesData, branch }) => {
   const itemsPerPage = 8
   const [pageIndex, setPageIndex] = useState({ curr: 1, total: 1 })
   const [filters, setFilters] = useState<{
-    status: string[]
+    kiStatus: string[]
     modules: string[]
-  }>({ status: [], modules: [] })
+  }>({ kiStatus: [], modules: [] })
   const [search, setSearch] = useState<string>('')
   const [sortByValue, setSortByValue] = useState<SortByType>('newest')
 
   const filteredResult = useMemo(() => {
-    const data = knownIssuesData.filter((knownIssue) => {
-      const hasFilter: boolean =
-        (filters.status.length === 0 ||
-          filters.status.includes(knownIssue.status)) &&
-        (filters.modules.length === 0 ||
-          filters.modules.includes(knownIssue.module))
+    const data = knownIssuesData
+      .filter((knownIssue) => knownIssue.status === 'PUBLISHED')
+      .filter((knownIssue) => {
+        const hasFilter: boolean =
+          (filters.kiStatus.length === 0 ||
+            filters.kiStatus.includes(knownIssue.kiStatus)) &&
+          (filters.modules.length === 0 ||
+            filters.modules.includes(knownIssue.module))
 
-      const hasSearch: boolean = knownIssue.title
-        .toLowerCase()
-        .includes(search.toLowerCase())
-      return hasFilter && hasSearch
-    })
+        const hasSearch: boolean = knownIssue.title
+          .toLowerCase()
+          .includes(search.toLowerCase())
+        return hasFilter && hasSearch
+      })
 
     data.sort((a, b) => {
       const dateA =
@@ -128,10 +130,10 @@ const KnownIssuesPage: NextPage<Props> = ({ knownIssuesData, branch }) => {
               tagFilter={knownIssuesStatusFilter(intl)}
               checkBoxFilter={knownIssuesModulesFilters(intl)}
               selectedCheckboxes={filters.modules}
-              selectedTags={filters.status}
+              selectedTags={filters.kiStatus}
               onApply={(newFilters) =>
                 setFilters({
-                  status: newFilters.tag,
+                  kiStatus: newFilters.tag,
                   modules: newFilters.checklist,
                 })
               }
@@ -242,9 +244,10 @@ export const getStaticProps: GetStaticProps = async ({
               title: frontmatter.title,
               module: frontmatter.tag,
               slug: data.slug,
-              status: frontmatter.kiStatus as KnownIssueStatus,
+              kiStatus: frontmatter.kiStatus as KnownIssueStatus,
               createdAt: String(frontmatter.createdAt),
               updatedAt: String(frontmatter.updatedAt),
+              status: frontmatter.status,
             })
         } catch (error) {
           logger.error(`${error}`)

--- a/src/pages/troubleshooting/[slug].tsx
+++ b/src/pages/troubleshooting/[slug].tsx
@@ -169,6 +169,19 @@ export const getStaticProps: GetStaticProps = async ({
       .then((res) => res.text())
       .catch((err) => console.log(err))) || ''
 
+  // Serialize content and parse frontmatter
+  const serialized = await serialize(documentationContent, {
+    parseFrontmatter: true,
+  })
+
+  // Check if status is "PUBLISHED"
+  const isPublished = serialized?.frontmatter?.status === 'PUBLISHED'
+  if (!isPublished) {
+    return {
+      notFound: true,
+    }
+  }
+
   const contributors =
     (await fetch(
       `https://github.com/vtexdocs/help-center-content/file-contributors/${branch}/${path}`,

--- a/src/pages/troubleshooting/index.tsx
+++ b/src/pages/troubleshooting/index.tsx
@@ -45,12 +45,14 @@ const TroubleshootingPage: NextPage<Props> = ({
   const [sortByValue, setSortByValue] = useState<SortByType>('newest')
 
   const filteredResult = useMemo(() => {
-    const data = troubleshootingData.filter((troubleshoot) => {
-      return (
-        filters.length === 0 ||
-        troubleshoot.tags.some((tag) => filters.includes(tag))
-      )
-    })
+    const data = troubleshootingData
+      .filter((troubleshoot) => troubleshoot.status === 'PUBLISHED')
+      .filter((troubleshoot) => {
+        return (
+          filters.length === 0 ||
+          troubleshoot.tags.some((tag) => filters.includes(tag))
+        )
+      })
 
     data.sort((a, b) => {
       const dateA =
@@ -207,6 +209,7 @@ export async function getStaticProps({
               createdAt: String(frontmatter.createdAt),
               updatedAt: String(frontmatter.updatedAt),
               tags: String(frontmatter.tags ?? '').split(','),
+              status: frontmatter.status,
             })
           }
         } catch (error) {

--- a/src/utils/typings/types.ts
+++ b/src/utils/typings/types.ts
@@ -69,11 +69,12 @@ export type KnownIssueStatus =
 export type KnownIssueDataElement = {
   title: string
   id: string
-  status: KnownIssueStatus
+  kiStatus: KnownIssueStatus
   module: string
   slug: string
   createdAt: string
   updatedAt: string
+  status: 'PUBLISHED' | 'DRAFT' | 'ARCHIVED' | 'CHANGED' | string
 }
 
 export type AnnouncementDataElement = {
@@ -81,6 +82,7 @@ export type AnnouncementDataElement = {
   url: string
   createdAt: string
   updatedAt: string
+  status: 'PUBLISHED' | 'DRAFT' | 'ARCHIVED' | 'CHANGED' | string
 }
 
 export type SortByType = 'newest' | 'recently_updated'
@@ -91,6 +93,7 @@ export type FaqCardDataElement = {
   createdAt: string
   updatedAt: string
   productTeam: string
+  status: 'PUBLISHED' | 'DRAFT' | 'ARCHIVED' | 'CHANGED' | string
 }
 
 export type TroubleshootingDataElement = {
@@ -99,4 +102,5 @@ export type TroubleshootingDataElement = {
   tags: string[]
   createdAt: string
   updatedAt: string
+  status: 'PUBLISHED' | 'DRAFT' | 'ARCHIVED' | 'CHANGED' | string
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

hiding unpublished content (where the frontmatter status is different from `PUBLISHED`), making their pages return 404 and removing them from lists of known issues, faq, announcements, and troubleshooting.

#### What problem is this solving?

https://github.com/vtexdocs/helpcenter/issues/105

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
