### PR TITLE
fix(preview pages)

### DIFF
--- a/src/pages/api/disable-preview.ts
+++ b/src/pages/api/disable-preview.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.clearPreviewData({})
+  res.redirect('/')
+}

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,0 +1,43 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import octokit from 'utils/octokitConfig'
+
+async function getGithubBranch(org: string, repo: string, branch: string) {
+  const response = octokit.request(
+    'GET /repos/{owner}/{repo}/branches/{branch}',
+    {
+      owner: org,
+      repo: repo,
+      branch: branch,
+    }
+  )
+  const branchExists = (await response).status == 200 ? true : false
+
+  return branchExists
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const branch = req.query.branch ? (req.query.branch as string) : 'main'
+
+  if (req.query.branch) {
+    let branchExists
+    try {
+      branchExists = await getGithubBranch(
+        'vtexdocs',
+        'help-center-content',
+        branch
+      )
+    } catch {
+      branchExists = false
+    }
+    if (branchExists) {
+      const customPreviewData = {
+        branch: `${branch}`,
+      }
+      res.setPreviewData(customPreviewData)
+    }
+  }
+  res.redirect('/')
+}


### PR DESCRIPTION
Restore preview api routes to restore content branch preview function

Testing:
1. Sync with this branch.
2. Run `yarn dev`.
3. Go to the preview url for branch `test-preview-2`:

```
http://localhost:3000/api/preview?branch=test-preview-2
```

4. Visit this article:

```
http://localhost:3000/pt/docs/tutorial/assembly-options
```

5. The first paragraph should be just the word `teste`.