### PR TITLE
fix(package.json): fix incorrect slug generation for words with accents

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/probe-image-size": "^7.2.0",
     "@types/uuid": "^9.0.0",
     "@vtex/brand-ui": "^0.46.1",
-    "@vtexdocs/components": "https://github.com/vtexdocs/components.git#v6.0.1",
+    "@vtexdocs/components": "https://github.com/vtexdocs/components.git#v6.0.3",
     "algoliasearch": "^4.14.2",
     "chalk": "^5.2.0",
     "copy-text-to-clipboard": "^3.0.1",

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -11,10 +11,13 @@ export const toCamelCase = (str: string) => {
 
 export const slugify = (str: string) => {
   return str
+    .normalize('NFD') // Decomposes diacritics (e.g., "é" → "é")
+    .replace(/[\u0300-\u036f]/g, '') // Removes diacritic marks
     .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/\-+/g, '-')
-    .replace(/[^a-z0-9\-]/g, '')
+    .replace(/[^\w\s-]/g, '') // Removes non-word characters except spaces and hyphens
+    .replace(/\s+/g, '-') // Replaces spaces with hyphens
+    .replace(/-+/g, '-') // Removes multiple consecutive hyphens
+    .trim() // Trims leading/trailing spaces
 }
 
 type Child = string | { props: { children: Child[] } }


### PR DESCRIPTION
This PR updates the slugify function (ToC) to correctly handle accented characters in Portuguese and Spanish. It now:
- Removes diacritics using normalize('NFD') (e.g., "condições" → "condicoes").
- Preserves word structure while keeping only alphanumeric characters, spaces, and hyphens.
- Fixes incorrect slug generation for accented words.

ID generation is addressed separately in [PR #39](https://github.com/vtexdocs/components/pull/39)