### PR TITLE
Mismatched locale slug handling

### DIFF
--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -25,6 +25,7 @@ import { Item, LibraryContext, TableOfContents } from '@vtexdocs/components'
 import Breadcrumb from 'components/breadcrumb'
 
 import getHeadings from 'utils/getHeadings'
+import redirectToLocalizedUrl from 'utils/redirectToLocalizedUrl'
 import getNavigation from 'utils/getNavigation'
 // import getGithubFile from 'utils/getGithubFile'
 import { getDocsPaths as getTracksPaths } from 'utils/getDocsPaths'
@@ -215,12 +216,6 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   const path = docsPaths[slug].find((e) => e.locale === locale)?.path
 
-  if (!path) {
-    return {
-      notFound: true,
-    }
-  }
-
   let documentationContent =
     (await fetch(
       `https://raw.githubusercontent.com/vtexdocs/help-center-content/${branch}/${path}`
@@ -290,7 +285,10 @@ export const getServerSideProps: GetServerSideProps = async ({
       },
     })
 
-    if (serialized.frontmatter?.status !== 'PUBLISHED') {
+    if (
+      serialized.frontmatter?.status &&
+      serialized.frontmatter?.status !== 'PUBLISHED'
+    ) {
       return {
         notFound: true,
       }
@@ -402,6 +400,16 @@ export const getServerSideProps: GetServerSideProps = async ({
           `Error: docsListName or currentLocale not found for slug: ${slug}`
         )
       }
+    }
+
+    if (!path) {
+      // If the path is not found, the function below redirects the user to the localized URL. If the localized URL is not found, it returns a 404 page.
+      return redirectToLocalizedUrl(
+        keyPath as string,
+        currentLocale,
+        flattenedSidebar,
+        'tracks'
+      )
     }
 
     // Ensure parentsArray does not contain undefined values

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -253,16 +253,6 @@ export const getServerSideProps: GetServerSideProps = async ({
       .catch((err) => console.log(err))) || []
 
   let format: 'md' | 'mdx' = 'mdx'
-  try {
-    if (path.endsWith('.md')) {
-      documentationContent = escapeCurlyBraces(documentationContent)
-      documentationContent = replaceHTMLBlocks(documentationContent)
-      documentationContent = await replaceMagicBlocks(documentationContent)
-    }
-  } catch (error) {
-    logger.error(`${error}`)
-    format = 'md'
-  }
 
   try {
     const headingList: Item[] = []
@@ -410,6 +400,17 @@ export const getServerSideProps: GetServerSideProps = async ({
         flattenedSidebar,
         'tracks'
       )
+    }
+
+    try {
+      if (path.endsWith('.md')) {
+        documentationContent = escapeCurlyBraces(documentationContent)
+        documentationContent = replaceHTMLBlocks(documentationContent)
+        documentationContent = await replaceMagicBlocks(documentationContent)
+      }
+    } catch (error) {
+      logger.error(`${error}`)
+      format = 'md'
     }
 
     // Ensure parentsArray does not contain undefined values

--- a/src/pages/docs/tutorials/[slug].tsx
+++ b/src/pages/docs/tutorials/[slug].tsx
@@ -189,6 +189,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   const keyPath = getKeyByValue(flattenedSidebar, slug)
 
   if (!keyPath) {
+    console.log('KeyPath not found (if (!keyPath)')
     return {
       notFound: true,
     }
@@ -300,14 +301,32 @@ export const getServerSideProps: GetServerSideProps = async ({
     }
   }
 
+  const keypathLocale = keyPath.split('slug.')[1]
+
   const docsPaths =
     process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
       ? docsPathsGLOBAL
       : await getTutorialsPaths('tutorials', branch)
 
-  const path = docsPaths[slug]?.find((e) => e.locale === locale)?.path
+  let path = ''
+  if (locale === keypathLocale) {
+    path = docsPaths[slug]?.find((e) => e.locale === locale)?.path
+  } else {
+    const keyPathWithoutLocale = keyPath.split('.slug')[0]
+    const localizedSlug =
+      flattenedSidebar[`${keyPathWithoutLocale}.slug.${locale}`]
+    if (localizedSlug) {
+      return {
+        redirect: {
+          destination: `/${locale}/docs/tutorials/${localizedSlug}`,
+          permanent: true,
+        },
+      }
+    }
+  }
 
   if (!path) {
+    console.log('Path not found (if (!path))')
     return {
       notFound: true,
     }

--- a/src/pages/docs/tutorials/[slug].tsx
+++ b/src/pages/docs/tutorials/[slug].tsx
@@ -15,6 +15,7 @@ import remarkImages from 'utils/remark_plugins/plaiceholder'
 import { Item, LibraryContext } from '@vtexdocs/components'
 
 import getHeadings from 'utils/getHeadings'
+import redirectToLocalizedUrl from 'utils/redirectToLocalizedUrl'
 import getNavigation from 'utils/getNavigation'
 // import getGithubFile from 'utils/getGithubFile'
 import { getDocsPaths as getTutorialsPaths } from 'utils/getDocsPaths'
@@ -189,25 +190,8 @@ export const getServerSideProps: GetServerSideProps = async ({
   const keyPath = getKeyByValue(flattenedSidebar, slug)
 
   if (!keyPath) {
-    console.log('KeyPath not found (if (!keyPath)')
     return {
       notFound: true,
-    }
-  } else {
-    const keypathLocale = keyPath.split('slug.')[1]
-
-    if (!(locale === keypathLocale)) {
-      const keyPathWithoutLocale = keyPath.split('.slug')[0]
-      const localizedSlug =
-        flattenedSidebar[`${keyPathWithoutLocale}.slug.${locale}`]
-      if (localizedSlug) {
-        return {
-          redirect: {
-            destination: `/${locale}/docs/tutorials/${localizedSlug}`,
-            permanent: true,
-          },
-        }
-      }
     }
   }
 
@@ -324,10 +308,13 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   const path = docsPaths[slug]?.find((e) => e.locale === locale)?.path
   if (!path) {
-    console.log('Path not found (if (!path))')
-    return {
-      notFound: true,
-    }
+    // If the path is not found, the function below redirects the user to the localized URL. If the localized URL is not found, it returns a 404 page.
+    return redirectToLocalizedUrl(
+      keyPath,
+      currentLocale,
+      flattenedSidebar,
+      'tutorials'
+    )
   }
 
   let documentationContent = await fetch(

--- a/src/pages/docs/tutorials/[slug].tsx
+++ b/src/pages/docs/tutorials/[slug].tsx
@@ -193,6 +193,22 @@ export const getServerSideProps: GetServerSideProps = async ({
     return {
       notFound: true,
     }
+  } else {
+    const keypathLocale = keyPath.split('slug.')[1]
+
+    if (!(locale === keypathLocale)) {
+      const keyPathWithoutLocale = keyPath.split('.slug')[0]
+      const localizedSlug =
+        flattenedSidebar[`${keyPathWithoutLocale}.slug.${locale}`]
+      if (localizedSlug) {
+        return {
+          redirect: {
+            destination: `/${locale}/docs/tutorials/${localizedSlug}`,
+            permanent: true,
+          },
+        }
+      }
+    }
   }
 
   const keyPathType = keyPath.split('slug')[0].concat('type')
@@ -301,30 +317,12 @@ export const getServerSideProps: GetServerSideProps = async ({
     }
   }
 
-  const keypathLocale = keyPath.split('slug.')[1]
-
   const docsPaths =
     process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
       ? docsPathsGLOBAL
       : await getTutorialsPaths('tutorials', branch)
 
-  let path = ''
-  if (locale === keypathLocale) {
-    path = docsPaths[slug]?.find((e) => e.locale === locale)?.path
-  } else {
-    const keyPathWithoutLocale = keyPath.split('.slug')[0]
-    const localizedSlug =
-      flattenedSidebar[`${keyPathWithoutLocale}.slug.${locale}`]
-    if (localizedSlug) {
-      return {
-        redirect: {
-          destination: `/${locale}/docs/tutorials/${localizedSlug}`,
-          permanent: true,
-        },
-      }
-    }
-  }
-
+  const path = docsPaths[slug]?.find((e) => e.locale === locale)?.path
   if (!path) {
     console.log('Path not found (if (!path))')
     return {

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -33,7 +33,8 @@ import styles from 'styles/documentation-page'
 import { ContributorsType } from 'utils/getFileContributors'
 
 import { getLogger } from 'utils/logging/log-util'
-import { localeType } from 'utils/navigation-utils'
+import { flattenJSON, getKeyByValue, localeType } from 'utils/navigation-utils'
+import redirectToLocalizedUrl from 'utils/redirectToLocalizedUrl'
 import { MarkdownRenderer } from '@vtexdocs/components'
 import { remarkReadingTime } from 'utils/remark_plugins/remarkReadingTime'
 import { getDocsPaths as getFaqPaths } from 'utils/getDocsPaths'
@@ -187,9 +188,23 @@ export const getStaticProps: GetStaticProps = async ({
   const path = docsPaths[slug].find((e) => e.locale === currentLocale)?.path
 
   if (!path) {
-    return {
-      notFound: true,
+    const sidebarfallback = await getNavigation()
+    const flattenedSidebar = flattenJSON(sidebarfallback)
+    const keyPath = getKeyByValue(flattenedSidebar, slug)
+
+    if (!keyPath) {
+      return {
+        notFound: true,
+      }
     }
+
+    // If the path is not found, the function below redirects the user to the localized URL. If the localized URL is not found, it returns a 404 page.
+    return redirectToLocalizedUrl(
+      keyPath,
+      currentLocale,
+      flattenedSidebar,
+      'faq'
+    )
   }
 
   let documentationContent =

--- a/src/pages/troubleshooting/[slug].tsx
+++ b/src/pages/troubleshooting/[slug].tsx
@@ -152,7 +152,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }
 }
 
-export const getStaticProps: GetStaticProps = async ({
+export const getStaticProps: GetStaticProps<Props> = async ({
   params,
   locale,
   preview,
@@ -308,6 +308,8 @@ export const getStaticProps: GetStaticProps = async ({
         seeAlsoData,
         breadcrumbList,
         branch,
+        sectionSelected: 'troubleshooting',
+        content: documentationContent,
       },
       revalidate: 600,
     }

--- a/src/utils/redirectToLocalizedUrl.ts
+++ b/src/utils/redirectToLocalizedUrl.ts
@@ -1,0 +1,62 @@
+export default async function redirectToLocalizedUrl(
+  keyPath: string,
+  locale: 'en' | 'es' | 'pt',
+  flattenedSidebar: Record<string, string>,
+  docType:
+    | 'tutorials'
+    | 'tracks'
+    | 'announcements'
+    | 'faq'
+    | 'known-issues'
+    | 'troubleshooting'
+) {
+  const keypathLocale = keyPath.split('slug.')[1]
+
+  if (!(locale === keypathLocale)) {
+    const keyPathWithoutLocale = keyPath.split('.slug')[0]
+    const localizedSlug =
+      flattenedSidebar[`${keyPathWithoutLocale}.slug.${locale}`]
+    if (localizedSlug) {
+      const docTypePath = getDocTypePath(docType)
+      return {
+        redirect: {
+          destination: `/${locale}/${docTypePath}/${localizedSlug}`,
+          permanent: true,
+        },
+      }
+    } else {
+      return {
+        notFound: true,
+      }
+    }
+  } else {
+    return {
+      notFound: true,
+    }
+  }
+}
+
+function getDocTypePath(
+  docType:
+    | 'tutorials'
+    | 'tracks'
+    | 'announcements'
+    | 'faq'
+    | 'known-issues'
+    | 'troubleshooting'
+) {
+  switch (docType) {
+    case 'tutorials':
+      return 'docs/tutorials'
+    case 'tracks':
+      return 'docs/tracks'
+    case 'announcements':
+      return 'announcements'
+    case 'faq':
+      return 'faq'
+    case 'known-issues':
+      return 'known-issues'
+    case 'troubleshooting':
+      return 'troubleshooting'
+  }
+}

--- a/src/utils/redirectToLocalizedUrl.ts
+++ b/src/utils/redirectToLocalizedUrl.ts
@@ -1,3 +1,19 @@
+import { GetStaticPropsResult } from 'next'
+import { ContributorsType } from './getFileContributors'
+import { Item } from '@vtexdocs/components'
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+
+interface Props {
+  sectionSelected: string
+  breadcrumbList: { slug: string; name: string; type: string }[]
+  content: string
+  serialized: MDXRemoteSerializeResult
+  contributors: ContributorsType[]
+  path: string
+  headingList: Item[]
+  branch: string
+}
+
 export default async function redirectToLocalizedUrl(
   keyPath: string,
   locale: 'en' | 'es' | 'pt',
@@ -9,7 +25,7 @@ export default async function redirectToLocalizedUrl(
     | 'faq'
     | 'known-issues'
     | 'troubleshooting'
-) {
+): Promise<GetStaticPropsResult<Props>> {
   const keypathLocale = keyPath.split('slug.')[1]
 
   if (!(locale === keypathLocale)) {


### PR DESCRIPTION
This change fixes issue #202.

To test it you can try and access links with mismatched locale and slug. Examples:
- Tutorial: https://deploy-preview-209--leafy-mooncake-7c2e5e.netlify.app/es/docs/tutorials/how-my-account-works
- Track: https://deploy-preview-209--leafy-mooncake-7c2e5e.netlify.app/pt/docs/tracks/configuracion-inicial
- FAQ: https://deploy-preview-209--leafy-mooncake-7c2e5e.netlify.app/pt/faq/how-to-find-linkedin-pixel
- Troubleshooting: https://deploy-preview-209--leafy-mooncake-7c2e5e.netlify.app/en/troubleshooting/como-corregir-el-error-de-esquema-en-aplicaciones-b2b
- Annoucnement: https://deploy-preview-209--leafy-mooncake-7c2e5e.netlify.app/en/announcements/2024-09-18-alteracao-no-campo-availablequantity-da-api-de-busca

The expected behavior is that the browser is redirected to the correct slug, compatible with the locale indicated in the URL.