### PR TITLE
fix(tutorial-markdown-renderer): remove copy link button from h1

### DIFF
--- a/src/components/tutorial-markdown-render/index.tsx
+++ b/src/components/tutorial-markdown-render/index.tsx
@@ -87,16 +87,19 @@ const TutorialMarkdownRender = (props: Props) => {
                     <Breadcrumb breadcrumbList={props.breadcrumbList} />
                     <Text sx={styles.documentationTitle} className="title">
                       {props.serialized.frontmatter?.title}
-                      {/* Adiciona a propriedade justifyContent ao Flex para alinhar o botão à direita */}
-                      <Flex
-                        sx={{ display: 'flex', justifyContent: 'flex-end' }}
-                      >
-                        <CopyLinkButton />
-                      </Flex>
                     </Text>
                     <Text sx={styles.documentationExcerpt}>
                       {props.serialized.frontmatter?.excerpt}
                     </Text>
+                    <Flex
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'flex-end',
+                        marginBottom: '16px',
+                      }}
+                    >
+                      <CopyLinkButton />
+                    </Flex>
                   </header>
                   {props.serialized.frontmatter?.readingTime && (
                     <TimeToRead


### PR DESCRIPTION
This PR solves #207 .

The CopyLinkButton component was previously placed within the TutorialMarkdownRender component's header text. I changed it to be 'parallel' to the header text and tweeked the flex params so that it is displayed correctly.

## How to test

You can compare any given tutorial, such as [this one](https://leafy-mooncake-7c2e5e.netlify.app/pt/docs/tutorials/como-funciona-a-minha-conta) with the same version in the deploy preview. Upon inspecting the header element in dev mode, you should be able to spot the difference, like in the screenshots below.

### Before
![image](https://github.com/user-attachments/assets/1626ed0c-61c6-401b-bf44-af8db1ec2053)

### After
![image](https://github.com/user-attachments/assets/a1a655fe-d201-4ba8-8cbf-02aa33b28951)
