### PR TITLE
Traffic tests announcement bar

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@vtex/brand-ui'
 import styles from 'styles/documentation-page'
 import Header from 'components/header'
 import Footer from 'components/footer'
+import AnnouncementBar from './announcement-bar'
 
 import { DocumentationTitle, UpdatesTitle } from 'utils/typings/unionTypes'
 import Script from 'next/script'
@@ -106,6 +107,19 @@ export default function Layout({
 					`}
           </Script>
         </div>
+        <AnnouncementBar
+          type="info"
+          label={intl.formatMessage({
+            id: 'announcement_bar.label',
+          })}
+          closable={false}
+          action={{
+            button: intl.formatMessage({
+              id: 'announcement_bar.button',
+            }),
+            href: 'https://help.vtex.com/',
+          }}
+        />
         <CookieBar
           onAccept={() => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,4 +1,6 @@
 {
+  "announcement_bar.button": "Return to previous version",
+  "announcement_bar.label": "You're viewing our new beta Help Center. Your feedback helps us improve!",
   "landing_page_newsletter.title": "How can we help you?",
   "landing_page_newsletter.description": "Find answers, solutions, and guidance about the VTEX platform all in one place.",
   "landing_page_newsletter.policyText": "Read our ",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -1,4 +1,6 @@
 {
+  "announcement_bar.button": "Volver al portal anterior",
+  "announcement_bar.label": "Estás viendo nuestro nuevo Help Center beta. ¡Tus comentarios nos ayudan a mejorar!",
   "landing_page_newsletter.title": "¿En qué podemos ayudarte?",
   "landing_page_newsletter.description": "Encuentra respuestas, soluciones y orientación sobre la plataforma VTEX, todo en un solo lugar.",
   "landing_page_newsletter.policyText": "Read our ",

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -1,4 +1,6 @@
 {
+  "announcement_bar.button": "Voltar ao portal anterior",
+  "announcement_bar.label": "Você está visualizando nosso novo Help Center beta. Seu feedback nos ajuda a melhorar!",
   "landing_page_newsletter.title": "Como podemos ajudar?",
   "landing_page_newsletter.description": "Encontre respostas, soluções e orientações sobre a plataforma VTEX em um só lugar.",
   "landing_page_newsletter.policyText": "Read our ",


### PR DESCRIPTION
Add announcement bar allowing users to return to previous version during the traffic tests with the new portal.

[Deploy preview](https://deploy-preview-231--leafy-mooncake-7c2e5e.netlify.app/pt)