### PR TITLE
Fix: Remove 544px width limitation from article content

### DIFF
--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -162,7 +162,7 @@ const indexContainer: SxStyleProp = {
 }
 
 const textContainer: SxStyleProp = {
-  width: ['100%', '544px'],
+  width: '100%',
   gap: '8px',
   pb: '43px',
   mb: '64px',


### PR DESCRIPTION
## Summary

This PR removes the artificial 544px width limitation from the  in documentation pages, allowing article content to use the full available width on larger screens.

## Changes Made

- **Modified **:
  - Changed  from  to 
  - This removes the 544px constraint that was applied to tablet+ screen sizes

## Problem Solved

Previously, article/markdown content was artificially constrained to 544px width on larger screens, making the text appear narrower than expected compared to other layouts like devportal. This fix allows the content to flow naturally within the available space while still respecting the responsive padding and container constraints.

## Testing

- ✅ Development server runs without errors
- ✅ Article content now uses full available width on all screen sizes
- ✅ Responsive behavior maintained through parent container controls
- ✅ No breaking changes to existing layout system

## Impact

- **Improved readability** on larger screens with better use of available space
- **Consistent layout behavior** across different screen sizes
- **Better alignment** with responsive design principles