### PR TITLE
feat: localize article pagination

### DIFF
--- a/src/components/article-pagination/index.tsx
+++ b/src/components/article-pagination/index.tsx
@@ -1,5 +1,6 @@
 import { Link, Grid, Text, Box } from '@vtex/brand-ui'
 import { useRouter } from 'next/router'
+import { useIntl } from 'react-intl'
 interface Props {
   pagination: {
     previousDoc: {
@@ -23,6 +24,7 @@ const ArticlePagination = ({
   hidePaginationPrevious,
 }: Props) => {
   const router = useRouter()
+  const intl = useIntl()
 
   const handleClick = (e: { preventDefault: () => void }, slug: string) => {
     e.preventDefault()
@@ -45,7 +47,12 @@ const ArticlePagination = ({
                 <Text sx={styles.paginationText}>
                   {pagination.previousDoc.name}
                 </Text>
-                <Text sx={styles.subTitle}>« Previous</Text>
+                <Text sx={styles.subTitle}>
+                  {`« ${intl.formatMessage({
+                    id: 'article_pagination.previous',
+                    defaultMessage: 'Previous',
+                  })}`}
+                </Text>
               </Box>
             </Link>
           )}
@@ -69,7 +76,12 @@ const ArticlePagination = ({
                 <Text sx={styles.paginationText}>
                   {pagination.nextDoc.name}
                 </Text>
-                <Text sx={styles.subTitle}>Next »</Text>
+                <Text sx={styles.subTitle}>
+                  {`${intl.formatMessage({
+                    id: 'article_pagination.next',
+                    defaultMessage: 'Next',
+                  })} »`}
+                </Text>
               </Box>
             </Link>
           )}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -79,6 +79,8 @@
   "announcements_page.see_more": "See more",
   "api_reference_page.title": "API Reference",
   "api_reference_page.subtitle": "Use our API reference documentation to build custom solutions that fit your business.",
+  "article_pagination.previous": "Previous",
+  "article_pagination.next": "Next",
   "start_here_page.title": "Start here",
   "start_here_page.link": "Learn more",
   "start_here_page.subtitle": "Learn, step by step, everything you need to know to start using VTEX.",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -79,6 +79,8 @@
   "announcements_page.see_more": "Vea mas",
   "api_reference_page.title": "API Reference",
   "api_reference_page.subtitle": "Use our API reference documentation to build custom solutions that fit your business.",
+  "article_pagination.previous": "Anterior",
+  "article_pagination.next": "Siguiente",
   "start_here_page.title": "Comience aquí",
   "start_here_page.link": "Aprenda más",
   "start_here_page.subtitle": "Aprende, paso a paso, todo lo que necesitas saber para empezar a usar VTEX.",

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -79,6 +79,8 @@
   "announcements_page.see_more": "Veja mais",
   "api_reference_page.title": "API Reference",
   "api_reference_page.subtitle": "Use our API reference documentation to build custom solutions that fit your business.",
+  "article_pagination.previous": "Anterior",
+  "article_pagination.next": "Próximo",
   "start_here_page.title": "Comece aqui",
   "start_here_page.link": "Saiba mais",
   "start_here_page.subtitle": "Aprenda, passo a passo, tudo que precisa saber para começar a usar a VTEX.",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Localization of the article pagination component.

#### What problem is this solving?

[EDU-15740](https://vtex-dev.atlassian.net/browse/EDU-15740)
Article pagination was always in English regardless of the selected locale.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
