### PR TITLE
fix(header): fix announcement bar and header behavior

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -21,6 +21,7 @@ import LocaleSwitcher from 'components/locale-switcher'
 import styles from './styles'
 import { PreviewContext } from 'utils/contexts/preview'
 import { FormattedMessage } from 'react-intl'
+import { useIntl } from 'react-intl'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Header = () => {
@@ -33,6 +34,7 @@ const Header = () => {
   const modalOpen = useRef(false)
   const [showDropdown, setShowDropdown] = useState(false)
   const headerElement = useRef<HTMLElement>()
+  const intl = useIntl()
 
   useEffect(() => {
     const body = document.body
@@ -87,7 +89,21 @@ const Header = () => {
 
   return (
     <Box ref={headerElement} sx={styles.headerContainer}>
-      {!isBranchPreview ? null : (
+      {!isBranchPreview ? (
+        <AnnouncementBar
+          type="info"
+          label={intl.formatMessage({
+            id: 'announcement_bar.label',
+          })}
+          closable={false}
+          action={{
+            button: intl.formatMessage({
+              id: 'announcement_bar.button',
+            }),
+            href: 'https://help.vtex.com?utm_source=new-help-center-announcement-bar',
+          }}
+        />
+      ) : (
         <AnnouncementBar
           closable={false}
           type="warning"

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,7 +8,6 @@ import { ThemeProvider } from '@vtex/brand-ui'
 import styles from 'styles/documentation-page'
 import Header from 'components/header'
 import Footer from 'components/footer'
-import AnnouncementBar from './announcement-bar'
 
 import { DocumentationTitle, UpdatesTitle } from 'utils/typings/unionTypes'
 import Script from 'next/script'
@@ -97,19 +96,6 @@ export default function Layout({
 					`}
           </Script>
         </div>
-        <AnnouncementBar
-          type="info"
-          label={intl.formatMessage({
-            id: 'announcement_bar.label',
-          })}
-          closable={false}
-          action={{
-            button: intl.formatMessage({
-              id: 'announcement_bar.button',
-            }),
-            href: 'https://help.vtex.com?utm_source=new-help-center-announcement-bar',
-          }}
-        />
         <CookieBar
           onAccept={() => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes the behavior of the scrolling header. Previously, the header would disappear when the user scrolled down the page, disrupting navigation and accessibility. With this fix, the header now remains visible (sticky) as the user scrolls, improving usability and ensuring consistent access to key actions or navigation elements.

|**Before:**|**Now:**|
|--|---|
|<img width="1470" height="796" alt="Screenshot 2025-08-04 at 11 20 59" src="https://github.com/user-attachments/assets/2a75515e-dbe9-4e52-9dc4-84e43c213640" />|<img width="1470" height="796" alt="Screenshot 2025-08-04 at 11 23 32" src="https://github.com/user-attachments/assets/3aea4bfb-3fb8-47a6-9801-5f1e3246a1e6" />

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
