### PR TITLE
fix(announcements): avoid undefined synopsis in getStaticProps

### DIFF
--- a/src/pages/announcements/index.tsx
+++ b/src/pages/announcements/index.tsx
@@ -193,15 +193,25 @@ export const getStaticProps: GetStaticProps = async ({
     for (const { content, slug } of batchResults) {
       if (!content) continue
       const frontmatter = await parseFrontmatter(content, logger)
-      if (frontmatter && (frontmatter.status == 'PUBLISHED' || 'CHANGED')) {
-        announcementsData.push({
+      // Only include published or changed announcements
+      if (
+        frontmatter &&
+        (frontmatter.status === 'PUBLISHED' || frontmatter.status === 'CHANGED')
+      ) {
+        const base: AnnouncementDataElement = {
           title: String(frontmatter.title),
           url: `announcements/${slug}`,
           createdAt: String(frontmatter.createdAt),
           updatedAt: String(frontmatter.updatedAt),
           status: String(frontmatter.status),
-          synopsis: getAnnouncementSynopsis(frontmatter, currentLocale),
-        })
+        }
+
+        const synopsis = getAnnouncementSynopsis(frontmatter, currentLocale)
+        if (synopsis !== undefined) {
+          base.synopsis = synopsis
+        }
+
+        announcementsData.push(base)
       }
     }
   }


### PR DESCRIPTION
This PR fixes Next.js pre-render errors on the announcements listing page by ensuring undefined values are not serialized.

Changes
- Only include announcements with status PUBLISHED or CHANGED in getStaticProps
- Avoid returning undefined for synopsis; omit the field unless present

Why
Builds were failing with messages like:
Error serializing `.announcementsData[NNN].synopsis` returned from  in /announcements. Reason:  cannot be serialized as JSON. Please use  or omit this value.

Refs: Next.js docs message: https://nextjs.org/docs/messages/prerender-error