### PR TITLE
fix(redirect edge function): fix redirect edge function

### DIFF
--- a/netlify/edge-functions/redirect-from-old-portal.js
+++ b/netlify/edge-functions/redirect-from-old-portal.js
@@ -8,7 +8,7 @@ export default async (request, context) => {
   // /<locale>/{type}/{slug}[--<key>]
   // /{type}/{slug}[--<key>]
   const match = url.pathname.match(
-    /^(?:\/(?<locale>[a-z]{2}))?\/(?<type>tutorial|announcements|tracks|faq)\/(?<slug>[^/]+?)(?:--[^/]+)?$/
+    /^(?:\/(?<locale>[a-z]{2}))?\/(?<type>tutorial|announcements|tracks|faq)\/(?<slug>[^/]+?)(?:--[^/]+)?(?:\/[^/]+)?$/
   )
 
   if (match && match.groups) {


### PR DESCRIPTION
This change acomodates tracks links which often contain `:track-key/:track-article-key` at the end of the URL.
