### PR TITLE
fix: change feedback prefill url to help.vtex.com

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -37,7 +37,7 @@ const FourOhFour: Page<Props> = ({ branch }) => {
             <Button sx={styles.button}>
               <Link
                 sx={styles.buttonLink}
-                href="https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=developers.vtex.com&entry.1799503232="
+                href="https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=help.vtex.com&entry.1799503232="
               >
                 CONTACT US
               </Link>

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -34,7 +34,7 @@ const FiveHundredPage: Page<Props> = ({ branch }) => {
             <Button sx={styles.button}>
               <Link
                 sx={styles.buttonLink}
-                href="https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=developers.vtex.com&entry.1799503232="
+                href="https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=help.vtex.com&entry.1799503232="
               >
                 CONTACT US
               </Link>

--- a/src/utils/get-url.tsx
+++ b/src/utils/get-url.tsx
@@ -1,5 +1,5 @@
 export const getFeedbackURL = () => {
-  return `https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=developers.vtex.com&entry.1799503232=`
+  return `https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=help.vtex.com&entry.1799503232=`
 }
 
 export const getDeveloperPortalURL = () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

When clicking the feedback button, the form was prefilled with developers.vtex.com. This changes the value to help.vtex.com.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
