### PR TITLE
feat: add edge function redirects for subcategory paths

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -51,6 +51,22 @@ function = "redirect-from-old-portal"
   path = "/:locale/announcements/*--*"
   function = "redirect-from-old-portal"
 
+[[edge_functions]]
+  path = "/subcategory/*--*"
+  function = "redirect-from-old-portal"
+
+[[edge_functions]]
+  path = "/:locale/subcategory/*--*"
+  function = "redirect-from-old-portal"
+
+[[edge_functions]]
+  path = "/subcategory/*"
+  function = "redirect-from-old-portal"
+
+[[edge_functions]]
+  path = "/:locale/subcategory/*"
+  function = "redirect-from-old-portal"
+
 [[redirects]]
 force = true
 from = "/:locale/docs/tutorials/creating-multi-store-multi-domain"


### PR DESCRIPTION
This PR adds edge function redirects for subcategory paths to handle old portal redirects properly, including both with and without locale prefixes.