### PR TITLE
fix: import redirects.json at build time to prevent infinite loop

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@ public/
 .cache/
 .next/
 src/utils/getGithubFile.ts
+netlify/edge-functions/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ public/
 .vscode/
 .cache/
 .next/
+netlify/edge-functions/


### PR DESCRIPTION
## Problem

The edge function was fetching `/redirects.json` at runtime, which was being intercepted by the catch-all route `/*`, creating an infinite redirect loop that resulted in 500 errors.

## Solution

Import `redirects.json` at build time using Deno's JSON import syntax instead of fetching it at runtime. This ensures the data is bundled into the edge function and prevents any runtime fetch that could trigger the redirect loop.

## Changes

- Updated `netlify/edge-functions/redirect-from-old-portal.js` to use `import ... with { type: 'json' }` syntax
- Added `netlify/edge-functions/` to `.eslintignore` to prevent parser conflicts with modern Deno syntax
- Added `netlify/edge-functions/` to `.prettierignore` to prevent formatting errors with import attributes

## Technical Notes

- Using the modern `with` syntax instead of deprecated `assert` (Netlify is ending support for `assert` on January 31st, 2026)
- The JSON data is loaded once during edge function bundling, not on every request
- ESLint and Prettier don't yet support the `with` syntax, hence the ignore rules