### PR TITLE
fix: import redirects.json at build time to prevent infinite loop

### DIFF
--- a/netlify/edge-functions/redirect-from-old-portal.js
+++ b/netlify/edge-functions/redirect-from-old-portal.js
@@ -79,6 +79,20 @@ export default async (request, context) => {
     console.log('slug', slug)
     console.log('search', search)
 
+    // Skip modern paths that don't need redirecting
+    if (type === 'announcements' && slug.match(/^\d{4}-\d{2}-\d{2}-/)) {
+      console.log('Modern announcement detected (date-prefixed), skipping redirect')
+      return context.next()
+    }
+    if (type === 'faq' && !slug.match(/--[^/]+$/)) {
+      console.log('Modern FAQ detected (no article key), skipping redirect')
+      return context.next()
+    }
+    if (type === 'known-issues' && !slug.match(/--[^/]+$/) && !slug.startsWith('ki--')) {
+      console.log('Modern known-issue detected (no article key, not ki-- format), skipping redirect')
+      return context.next()
+    }
+
     if (type === 'tutorial') {
       destination = `/${locale}/docs/tutorials/${slug}`
     } else if (type === 'subcategory') {


### PR DESCRIPTION
## Problem

The edge function was fetching `/redirects.json` at runtime, which was being intercepted by the catch-all route `/*`, creating an infinite redirect loop that resulted in 500 errors. Additionally, modern announcement URLs were redirecting to themselves, creating loops.

## Solution

Import `redirects.json` at build time using Deno's JSON import syntax instead of fetching it at runtime. This ensures the data is bundled into the edge function and prevents any runtime fetch that could trigger the redirect loop.

## Changes

### Edge Function
- Import `redirects.json` at build time using `import ... with { type: 'json' }` syntax
- Add catch-all route `/*` to handle hostname redirects (`newhelp.vtex.com` → `help.vtex.com`)
- Yield early for `/api/*` routes and static files (images, CSS, JS, fonts)
- Skip modern announcements with date prefix (YYYY-MM-DD-...) to prevent redirect loops
- Skip modern FAQ and known-issues without article keys to prevent redirect loops
- Process legacy redirect patterns from imported JSON data
- Call `context.next()` for non-matching paths to pass through to Next.js

### Configuration
- Add `netlify/edge-functions/` to `.eslintignore` to prevent parser conflicts
- Add `netlify/edge-functions/` to `.prettierignore` to prevent formatting errors
- Add catch-all edge function route in `netlify.toml`

### Bug Fixes
- Fix hardcoded support URL from `/en/support` to `/support`

## Technical Notes

- Using modern `with` syntax instead of deprecated `assert` (Netlify ending support for `assert` on January 31st, 2026)
- JSON data is loaded once during edge function bundling, not on every request
- No infinite loops - the edge function never makes runtime requests to `/redirects.json`
- Hostname redirect works on all paths via catch-all route
- Modern URLs (announcements, FAQ, known-issues) pass through without redirect processing
- ESLint and Prettier don't yet support the `with` syntax, hence the ignore rules

## Testing

Tested locally with `netlify dev`:
- ✅ Homepage loads successfully
- ✅ Legacy redirects work (e.g., `/faq/mercado-libre-faq` → `/en/docs/tutorials/mercado-libre-faq`)
- ✅ Modern announcements pass through without loops (`/en/announcements/2025-11-07-...`)
- ✅ Static files are accessible
- ✅ Modern docs pages load correctly
- ✅ No infinite loops
- ✅ Hostname redirect logic in place for production