### PR TITLE
feat: unify ISR revalidation configuration

### DIFF
--- a/src/pages/announcements/[slug].tsx
+++ b/src/pages/announcements/[slug].tsx
@@ -28,6 +28,7 @@ import { sanitizeArray } from 'utils/sanitizeArrays'
 import { getSeeAlsoData } from 'utils/article-page/getSeeAlsoData'
 import { getMessages } from 'utils/get-messages'
 import type { SectionId } from 'utils/typings/unionTypes'
+import { getCategoryCoverRevalidateTime } from 'utils/config'
 // Initialize in getStaticProps
 const docsPathsGLOBAL: Record<
   string,
@@ -240,7 +241,7 @@ export const getStaticProps: GetStaticProps = async ({
           },
           locale: currentLocale,
         },
-        revalidate: 3600,
+        revalidate: getCategoryCoverRevalidateTime(),
       }
     }
   }
@@ -307,7 +308,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 3600,
+      revalidate: getCategoryCoverRevalidateTime(),
     }
   }
 

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -31,6 +31,10 @@ import { ArticlePageProps } from 'utils/typings/types'
 import { getSeeAlsoData } from 'utils/article-page/getSeeAlsoData'
 import { getMessages } from 'utils/get-messages'
 import type { SectionId } from 'utils/typings/unionTypes'
+import {
+  getArticleRevalidateTime,
+  getCategoryCoverRevalidateTime,
+} from 'utils/config'
 
 // Initialize in getStaticProps
 const docsPathsGLOBAL: Record<
@@ -253,7 +257,7 @@ export const getStaticProps: GetStaticProps = async ({
           },
           locale: currentLocale,
         },
-        revalidate: 3600,
+        revalidate: getCategoryCoverRevalidateTime(),
       }
     }
   }
@@ -320,7 +324,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 3600,
+      revalidate: getArticleRevalidateTime(),
     }
   }
 

--- a/src/pages/docs/tutorials/[slug].tsx
+++ b/src/pages/docs/tutorials/[slug].tsx
@@ -32,6 +32,10 @@ import {
   checkTroubleshootingFallback,
   createTroubleshootingRedirect,
 } from 'utils/checkTroubleshootingFallback'
+import {
+  getArticleRevalidateTime,
+  getCategoryCoverRevalidateTime,
+} from 'utils/config'
 
 // Initialize in getStaticProps
 const docsPathsGLOBAL: Record<
@@ -274,7 +278,7 @@ export const getStaticProps: GetStaticProps = async ({
           },
           locale: currentLocale,
         },
-        revalidate: 3600,
+        revalidate: getCategoryCoverRevalidateTime(),
       }
     }
   }
@@ -342,7 +346,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 3600,
+      revalidate: getArticleRevalidateTime(),
     }
   }
 

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -24,6 +24,10 @@ import ArticleRender from 'components/article-render'
 import ArticleIndex from 'components/article-index'
 import type { SectionId } from 'utils/typings/unionTypes'
 import { ArticlePageProps } from 'utils/typings/types'
+import {
+  getArticleRevalidateTime,
+  getCategoryCoverRevalidateTime,
+} from 'utils/config'
 
 // Initialize in getStaticProps
 const docsPathsGLOBAL: Record<
@@ -227,7 +231,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 3600,
+      revalidate: getCategoryCoverRevalidateTime(),
     }
   }
 
@@ -291,7 +295,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 600,
+      revalidate: getArticleRevalidateTime(),
     }
   }
   logger.error(`Markdown file does not exist for ${slug}`)

--- a/src/pages/known-issues/[slug].tsx
+++ b/src/pages/known-issues/[slug].tsx
@@ -25,6 +25,10 @@ import { isCategoryCover } from 'utils/article-page/getPagination'
 import { sanitizeArray } from 'utils/sanitizeArrays'
 import { getSeeAlsoData } from 'utils/article-page/getSeeAlsoData'
 import type { SectionId } from 'utils/typings/unionTypes'
+import {
+  getArticleRevalidateTime,
+  getCategoryCoverRevalidateTime,
+} from 'utils/config'
 
 // Initialize in getStaticProps
 const docsPathsGLOBAL: Record<
@@ -244,7 +248,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 3600,
+      revalidate: getCategoryCoverRevalidateTime(),
     }
   }
 
@@ -307,7 +311,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 600,
+      revalidate: getArticleRevalidateTime(),
     }
   }
   logger.error(`Error while processing ${params?.slug}`)

--- a/src/pages/troubleshooting/[slug].tsx
+++ b/src/pages/troubleshooting/[slug].tsx
@@ -21,6 +21,10 @@ import ArticleIndex from 'components/article-index'
 import { ArticlePageProps } from 'utils/typings/types'
 import { getBreadcrumbsList } from 'utils/article-page/getBreadcrumbsList'
 import { sanitizeArray } from 'utils/sanitizeArrays'
+import {
+  getArticleRevalidateTime,
+  getCategoryCoverRevalidateTime,
+} from 'utils/config'
 
 // Initialize in getStaticProps
 const docsPathsGLOBAL: Record<
@@ -222,7 +226,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 3600,
+      revalidate: getCategoryCoverRevalidateTime(),
     }
   }
 
@@ -285,7 +289,7 @@ export const getStaticProps: GetStaticProps = async ({
         },
         locale: currentLocale,
       },
-      revalidate: 600,
+      revalidate: getArticleRevalidateTime(),
     }
   }
   logger.error(`Markdown file does not exist for ${slug}`)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -20,7 +20,7 @@ const getEnvironmentVariable = (environmentVariable: string): string => {
 }
 
 /**
- * Get ISR revalidate time from environment variable
+ * Get ISR revalidate time from environment variable for index/listing pages
  * @returns {number} Revalidate time in seconds (default: 600 seconds / 10 minutes)
  *
  * This function safely handles environments where ISR_REVALIDATE_SECONDS is not set
@@ -40,6 +40,62 @@ export const getISRRevalidateTime = (): number => {
   if (isNaN(parsed) || parsed <= 0) {
     console.warn(
       `Invalid ISR_REVALIDATE_SECONDS value: "${envValue}". Must be a positive integer. Using default: ${DEFAULT_REVALIDATE_SECONDS} seconds.`
+    )
+    return DEFAULT_REVALIDATE_SECONDS
+  }
+
+  return parsed
+}
+
+/**
+ * Get ISR revalidate time from environment variable for article/detail pages
+ * @returns {number} Revalidate time in seconds (default: 600 seconds / 10 minutes)
+ *
+ * This function safely handles environments where ISR_ARTICLE_REVALIDATE_SECONDS is not set
+ * and falls back to a sensible 10-minute default for documentation sites.
+ */
+export const getArticleRevalidateTime = (): number => {
+  const DEFAULT_REVALIDATE_SECONDS = 600 // 10 minutes
+  const envValue = process.env.ISR_ARTICLE_REVALIDATE_SECONDS
+
+  // Return default if environment variable is not set or empty
+  if (!envValue || envValue.trim() === '') {
+    return DEFAULT_REVALIDATE_SECONDS
+  }
+
+  // Parse and validate the environment variable value
+  const parsed = parseInt(envValue.trim(), 10)
+  if (isNaN(parsed) || parsed <= 0) {
+    console.warn(
+      `Invalid ISR_ARTICLE_REVALIDATE_SECONDS value: "${envValue}". Must be a positive integer. Using default: ${DEFAULT_REVALIDATE_SECONDS} seconds.`
+    )
+    return DEFAULT_REVALIDATE_SECONDS
+  }
+
+  return parsed
+}
+
+/**
+ * Get ISR revalidate time from environment variable for category cover pages
+ * @returns {number} Revalidate time in seconds (default: 3600 seconds / 1 hour)
+ *
+ * This function safely handles environments where ISR_CATEGORY_REVALIDATE_SECONDS is not set
+ * and falls back to a sensible 1-hour default for documentation sites.
+ */
+export const getCategoryCoverRevalidateTime = (): number => {
+  const DEFAULT_REVALIDATE_SECONDS = 3600 // 1 hour
+  const envValue = process.env.ISR_CATEGORY_REVALIDATE_SECONDS
+
+  // Return default if environment variable is not set or empty
+  if (!envValue || envValue.trim() === '') {
+    return DEFAULT_REVALIDATE_SECONDS
+  }
+
+  // Parse and validate the environment variable value
+  const parsed = parseInt(envValue.trim(), 10)
+  if (isNaN(parsed) || parsed <= 0) {
+    console.warn(
+      `Invalid ISR_CATEGORY_REVALIDATE_SECONDS value: "${envValue}". Must be a positive integer. Using default: ${DEFAULT_REVALIDATE_SECONDS} seconds.`
     )
     return DEFAULT_REVALIDATE_SECONDS
   }


### PR DESCRIPTION
Centralizes control of all ISR (Incremental Static Regeneration) revalidation times through environment variables. Previously, revalidation times were hardcoded across different page types, making it difficult to adjust caching behavior globally.

## Changes

- **Added two new configuration functions** in `src/utils/config.ts`:
  - `getArticleRevalidateTime()` - Controls revalidation for article/detail pages (default: 600s)
  - `getCategoryCoverRevalidateTime()` - Controls revalidation for category cover pages (default: 3600s)

- **Replaced all hardcoded revalidation values** across 6 page files:
  - FAQ pages
  - Known Issues pages
  - Announcements pages
  - Troubleshooting pages
  - Tracks pages
  - Tutorials pages

## Environment Variables

All ISR cache timings are now configurable via:

| Variable | Controls | Default |
|----------|----------|---------|
| `ISR_REVALIDATE_SECONDS` | Index/listing pages | 600s (10 min) |
| `ISR_ARTICLE_REVALIDATE_SECONDS` | Article/detail pages | 600s (10 min) |
| `ISR_CATEGORY_REVALIDATE_SECONDS` | Category cover pages | 3600s (1 hour) |

## Benefits

✅ Single point of control for all ISR cache timings
✅ Environment-driven configuration (no code changes needed)
✅ Sensible defaults for each page type
✅ Consistent behavior across all sections
✅ Build verified with no TypeScript errors

## Example Usage

To set all pages to 1 hour revalidation:

```bash
ISR_REVALIDATE_SECONDS=3600
ISR_ARTICLE_REVALIDATE_SECONDS=3600
ISR_CATEGORY_REVALIDATE_SECONDS=3600
```