### PR TITLE
feat: load navigation from preview branch

### DIFF
--- a/src/pages/announcements/[slug].tsx
+++ b/src/pages/announcements/[slug].tsx
@@ -117,7 +117,7 @@ export const getStaticProps: GetStaticProps = async ({
   })
 
   const { keyPath, flattenedSidebar, sidebarfallback } =
-    await getSidebarMetadata(sectionSelected, slug)
+    await getSidebarMetadata(sectionSelected, slug, { branch })
 
   const isAnnouncementCategory = isCategoryCover(slug, sidebarfallback)
 

--- a/src/pages/api/navigation.ts
+++ b/src/pages/api/navigation.ts
@@ -1,125 +1,38 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import fs from 'fs'
-import path from 'path'
-import {
-  isRateLimited,
-  parseRateLimitHeaders,
-  formatRateLimitInfo,
-} from 'utils/githubRateLimitHandler'
-import { getCdnUrls } from 'utils/githubCdnFallback'
+import getNavigation from 'utils/getNavigation'
+import { getPreviewBranch } from 'utils/preview/getPreviewBranch'
+import { getLogger } from 'utils/logging/log-util'
 
-// Unified navigation API
-// - Prefers external URL via env.navigationJsonUrl
-// - Falls back to CDN mirrors (jsDelivr, Statically)
-// - Final fallback to local public/navigation.json
+const logger = getLogger('navigation-api')
+
 export default async function handler(
-  _req: NextApiRequest,
+  req: NextApiRequest,
   res: NextApiResponse
 ) {
   try {
-    const navigationJsonUrl = process.env.navigationJsonUrl
+    const branch = getPreviewBranch(req.preview, req.previewData)
+    const navbar = await getNavigation({ branch })
 
-    if (navigationJsonUrl) {
-      // Try primary URL
-      try {
-        const response = await fetch(navigationJsonUrl)
-
-        // Check for rate limiting (403 OR 429)
-        if (response.status === 403 || response.status === 429) {
-          if (isRateLimited(response)) {
-            const rateLimitInfo = parseRateLimitHeaders(response.headers)
-            // eslint-disable-next-line no-console
-            console.warn(
-              `navigation API: Rate limited. ${formatRateLimitInfo(
-                rateLimitInfo
-              )}`
-            )
-            // Fall through to CDN fallbacks
-          }
-        } else if (response.ok) {
-          const data = await response.json()
-          // Cache for 5 minutes on CDN, allow stale while revalidate for 30 minutes
-          res.setHeader(
-            'Cache-Control',
-            'public, s-maxage=300, stale-while-revalidate=1800'
-          )
-          res.setHeader(
-            'Netlify-CDN-Cache-Control',
-            'public, s-maxage=300, stale-while-revalidate=1800'
-          )
-          return res.status(200).json(data)
-        }
-
-        throw new Error(
-          `Failed to fetch navigation from URL: ${response.status}`
-        )
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'navigation API: external fetch failed, trying CDN fallbacks',
-          e
-        )
-
-        // Try CDN fallbacks
-        const cdnUrls = getCdnUrls(
-          'vtexdocs',
-          'help-center-content',
-          'main',
-          'public/navigation.json',
-          'jsdelivr'
-        )
-
-        for (const url of cdnUrls.slice(1)) {
-          // Skip first (already tried)
-          try {
-            const cdnType = url.includes('jsdelivr') ? 'jsDelivr' : 'Statically'
-            // eslint-disable-next-line no-console
-            console.info(`navigation API: Trying ${cdnType}`)
-            const response = await fetch(url)
-
-            if (response.ok) {
-              const data = await response.json()
-              // eslint-disable-next-line no-console
-              console.info(
-                `navigation API: Successfully fetched from ${cdnType}`
-              )
-              res.setHeader(
-                'Cache-Control',
-                'public, s-maxage=300, stale-while-revalidate=1800'
-              )
-              res.setHeader(
-                'Netlify-CDN-Cache-Control',
-                'public, s-maxage=300, stale-while-revalidate=1800'
-              )
-              return res.status(200).json(data)
-            }
-          } catch (cdnErr) {
-            // eslint-disable-next-line no-console
-            console.warn(`navigation API: ${url} failed`, cdnErr)
-            continue
-          }
-        }
-      }
+    if (req.preview) {
+      res.setHeader('Cache-Control', 'private, no-store')
+      res.setHeader('Netlify-CDN-Cache-Control', 'private, no-store')
+    } else {
+      res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=300, stale-while-revalidate=1800'
+      )
+      res.setHeader(
+        'Netlify-CDN-Cache-Control',
+        'public, s-maxage=300, stale-while-revalidate=1800'
+      )
     }
 
-    // Filesystem fallback
-    const filePath = path.join(process.cwd(), 'public', 'navigation.json')
-    const fileContent = fs.readFileSync(filePath, 'utf8')
-    const navigation = JSON.parse(fileContent)
-    // eslint-disable-next-line no-console
-    console.info('navigation API: Using filesystem fallback')
-    res.setHeader(
-      'Cache-Control',
-      'public, s-maxage=300, stale-while-revalidate=1800'
-    )
-    res.setHeader(
-      'Netlify-CDN-Cache-Control',
-      'public, s-maxage=300, stale-while-revalidate=1800'
-    )
-    return res.status(200).json(navigation)
+    return res.status(200).json({ navbar })
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('navigation API: failed to load navigation', error)
+    logger.error('failed to load navigation')
+    if (error instanceof Error) {
+      logger.error(error.message)
+    }
     return res.status(500).json({ error: 'Failed to load navigation' })
   }
 }

--- a/src/pages/docs/tracks/[slug].tsx
+++ b/src/pages/docs/tracks/[slug].tsx
@@ -133,7 +133,7 @@ export const getStaticProps: GetStaticProps = async ({
   })
 
   const { keyPath, flattenedSidebar, sidebarfallback } =
-    await getSidebarMetadata(sectionSelected, slug)
+    await getSidebarMetadata(sectionSelected, slug, { branch })
 
   const isTrackCover = isCategoryCover(slug, sidebarfallback)
 

--- a/src/pages/docs/tutorials/[slug].tsx
+++ b/src/pages/docs/tutorials/[slug].tsx
@@ -139,7 +139,7 @@ export const getStaticProps: GetStaticProps = async ({
   })
 
   const { keyPath, flattenedSidebar, sidebarfallback } =
-    await getSidebarMetadata(sectionSelected, slug)
+    await getSidebarMetadata(sectionSelected, slug, { branch })
 
   const isTutorialCategory = isCategoryCover(slug, sidebarfallback)
 

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -116,7 +116,7 @@ export const getStaticProps: GetStaticProps = async ({
   })
 
   const { keyPath, flattenedSidebar, sidebarfallback } =
-    await getSidebarMetadata(sectionSelected, slug)
+    await getSidebarMetadata(sectionSelected, slug, { branch })
 
   const isFaqCover = isCategoryCover(slug, sidebarfallback)
 

--- a/src/pages/known-issues/[slug].tsx
+++ b/src/pages/known-issues/[slug].tsx
@@ -134,7 +134,7 @@ export const getStaticProps: GetStaticProps = async ({
     docsPathsGLOBAL,
   })
   const { keyPath, flattenedSidebar, sidebarfallback } =
-    await getSidebarMetadata(sectionSelected, resolvedSlug)
+    await getSidebarMetadata(sectionSelected, resolvedSlug, { branch })
   const isKICover = isCategoryCover(slug, sidebarfallback)
 
   if (!mdFileExists && !isKICover) {

--- a/src/pages/troubleshooting/[slug].tsx
+++ b/src/pages/troubleshooting/[slug].tsx
@@ -113,7 +113,7 @@ export const getStaticProps: GetStaticProps = async ({
   })
 
   const { keyPath, flattenedSidebar, sidebarfallback } =
-    await getSidebarMetadata(sectionSelected, slug)
+    await getSidebarMetadata(sectionSelected, slug, { branch })
   const isTroubleshootingCover = isCategoryCover(slug, sidebarfallback)
 
   if (!mdFileExists && !isTroubleshootingCover) {

--- a/src/utils/article-page/getSidebarMetadata.ts
+++ b/src/utils/article-page/getSidebarMetadata.ts
@@ -1,11 +1,16 @@
 import getNavigation from '../getNavigation'
 import { flattenJSON, getKeyByValue } from '../navigation-utils'
 
+type SidebarMetadataOptions = {
+  branch?: string
+}
+
 export async function getSidebarMetadata(
   sectionSelected: string,
-  slug: string
+  slug: string,
+  options: SidebarMetadataOptions = {}
 ) {
-  const sidebar = await getNavigation()
+  const sidebar = await getNavigation({ branch: options.branch })
   const filtered = sidebar.find(
     (item: { documentation: string }) => item.documentation === sectionSelected
   )

--- a/src/utils/preview/getPreviewBranch.ts
+++ b/src/utils/preview/getPreviewBranch.ts
@@ -1,0 +1,31 @@
+import { getLogger } from '../logging/log-util'
+
+const logger = getLogger('getPreviewBranch')
+
+export function getPreviewBranch(
+  preview?: boolean,
+  previewData?: unknown,
+  fallbackBranch = 'main'
+): string {
+  if (!preview) {
+    return fallbackBranch
+  }
+
+  try {
+    const safePreviewData = JSON.parse(
+      JSON.stringify(previewData ?? {})
+    ) as Record<string, unknown>
+
+    const branch = safePreviewData?.branch
+
+    if (typeof branch === 'string' && branch.trim().length > 0) {
+      return branch.trim()
+    }
+  } catch (error) {
+    // Swallow JSON parse errors and fall back to default branch
+    const message = (error as Error).message ?? 'unknown error'
+    logger.warn(`failed to parse previewData: ${message}`)
+  }
+
+  return fallbackBranch
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Load navigation from the preview branch so preview sessions stay consistent across sidebar data and article content.

#### What problem is this solving?

Preview mode relied on main-branch navigation even when markdown content was loaded from an alternate branch. This caused sidebar links, breadcrumbs, and pagination to mismatch previewed articles. The change threads the preview branch through `getNavigation`, the navigation API, and all sidebar callers.

#### How should this be manually tested?

1. `git checkout feature/navigation-preview-branch`
2. `yarn install`
3. `yarn build` (ignore the existing `next-sitemap` `siteUrl` warning)
4. `netlify dev` in one terminal.
5. `curl -s http://localhost:8888/api/navigation | jq '.navbar | length'` in another terminal – should return 6 without hitting GitHub directly.
6. Enable preview mode against a non-main branch and confirm sidebar links resolve correctly.

#### Screenshots or example usage

N/A

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
