### PR TITLE
fix: update troubleshooting descriptions

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -360,11 +360,11 @@
   "faq_page.results_found": "results found",
   "chip.all_results": "All results",
   "troubleshooting_page.title": "Troubleshooting",
-  "troubleshooting_page.description": "Identify and fix issues independently and efficiently.",
+  "troubleshooting_page.description": "Identify and fix issues independently and efficiently",
   "menu_troubleshooting.title": "Troubleshooting",
-  "menu_troubleshooting.description": "Identify and fix issues independently and efficiently.",
+  "menu_troubleshooting.description": "Identify and fix issues independently and efficiently",
   "sidebar_troubleshooting.title": "Troubleshooting",
-  "sidebar_troubleshooting.description": "Identify and fix issues independently and efficiently.",
+  "sidebar_troubleshooting.description": "Identify and fix issues independently and efficiently",
   "troubleshooting_filter_tags.title": "Tags",
   "troubleshooting_page_search.placeholder": "Search for identified issues, diagnostics, and fixes..."
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -360,11 +360,11 @@
   "faq_page.results_found": "resultados encontrados",
   "chip.all_results": "Todos los resultados",
   "troubleshooting_page.title": "Resolución de problemas",
-  "troubleshooting_page.description": "Identifique y solucione problemas de manera autónoma y eficiente.",
+  "troubleshooting_page.description": "Identifique y solucione problemas de manera autónoma y eficiente",
   "menu_troubleshooting.title": "Resolución de problemas",
-  "menu_troubleshooting.description": "Identifique y solucione problemas de manera autónoma y eficiente.",
+  "menu_troubleshooting.description": "Identifique y solucione problemas de manera autónoma y eficiente",
   "sidebar_troubleshooting.title": "Resolución de problemas",
-  "sidebar_troubleshooting.description": "Identifique y solucione problemas de manera autónoma y eficiente.",
+  "sidebar_troubleshooting.description": "Identifique y solucione problemas de manera autónoma y eficiente",
   "troubleshooting_filter_tags.title": "Tags",
   "troubleshooting_page_search.placeholder": "Buscar identificación, diagnósticos y correcciones de fallas..."
 }

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -362,9 +362,9 @@
   "troubleshooting_page.title": "Troubleshooting",
   "troubleshooting_page.description": "Identifique e solucione problemas de maneira autônoma e eficiente",
   "menu_troubleshooting.title": "Troubleshooting",
-  "menu_troubleshooting.description": "Identifique e solucione problemas de maneira autônoma e eficiente.",
+  "menu_troubleshooting.description": "Identifique e solucione problemas de maneira autônoma e eficiente",
   "sidebar_troubleshooting.title": "Troubleshooting",
-  "sidebar_troubleshooting.description": "Identifique e solucione problemas de maneira autônoma e eficiente.",
+  "sidebar_troubleshooting.description": "Identifique e solucione problemas de maneira autônoma e eficiente",
   "troubleshooting_filter_tags.title": "Tags",
   "troubleshooting_page_search.placeholder": "Buscar identificações, diagnósticos e correções de falhas..."
 }


### PR DESCRIPTION
Updated troubleshooting descriptions in all language files (en, es, pt). Removing an unwanted period in the troubleshooting card and menu descriptions:
<img width="1633" height="434" alt="image" src="https://github.com/user-attachments/assets/aa2777e0-3cc3-47ae-97e5-ad09dfe8d24a" />
