### PR TITLE
feat: add current URL to feedback form links

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -46,7 +46,11 @@ const Footer = () => {
       message: intl.formatMessage({
         id: 'landing_page_footer_feedback.message',
       }),
-      to: () => getFeedbackURL(),
+      to: () => {
+        const currentUrl =
+          typeof window !== 'undefined' ? window.location.href : ''
+        return getFeedbackURL(currentUrl)
+      },
     },
   ]
 

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -42,7 +42,14 @@ const Header = () => {
   const lastScroll = useRef(0)
   const modalOpen = useRef(false)
   const [showDropdown, setShowDropdown] = useState(false)
+  const [currentUrl, setCurrentUrl] = useState<string>('')
   const headerElement = useRef<HTMLElement>()
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setCurrentUrl(window.location.href)
+    }
+  }, [router.asPath])
 
   useEffect(() => {
     const body = document.body
@@ -141,7 +148,7 @@ const Header = () => {
 
           <VtexLink
             sx={styles.rightLinksItem}
-            href={getFeedbackURL()}
+            href={getFeedbackURL(currentUrl)}
             target="_blank"
           >
             <LongArrowIcon />

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { Flex, Box } from '@vtex/brand-ui'
 import type { ReactElement } from 'react'
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
 import { TrackerContext } from 'utils/contexts/trackerContext'
 import { useClientNavigation } from 'utils/useClientNavigation'
 import { ThemeProvider } from '@vtex/brand-ui'
@@ -51,6 +52,8 @@ export default function Layout({
   const { initTracker, startTracking } = useContext(TrackerContext)
   const { navigation } = useClientNavigation() // Load navigation client-side
   const intl = useIntl()
+  const router = useRouter()
+  const [currentUrl, setCurrentUrl] = useState<string>('')
 
   useEffect(() => {
     // Lazy load tracker to avoid blocking main thread
@@ -61,6 +64,12 @@ export default function Layout({
 
     return () => clearTimeout(timer)
   }, [])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setCurrentUrl(window.location.href)
+    }
+  }, [router.asPath])
 
   return (
     <ThemeProvider>
@@ -74,7 +83,7 @@ export default function Layout({
           menuDocumentationData(intl),
           menuSupportData(intl),
           updatesData(intl),
-          feedbackSectionData(intl),
+          feedbackSectionData(intl, currentUrl),
         ]}
         sectionSelected={sectionSelected ?? ''}
         fallback={navigation} // Use client-side loaded navigation (null during loading)

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,8 +5,9 @@ import { Box, Flex, Text, Button, Link } from '@vtex/brand-ui'
 import styles from 'styles/error-page'
 import fourOhFourImage from '../../public/images/404-illustration.png'
 import { GetStaticProps } from 'next'
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { PreviewContext } from 'utils/contexts/preview'
+import { getFeedbackURL } from 'utils/get-url'
 
 interface Props {
   branch: string
@@ -15,6 +16,13 @@ interface Props {
 const FourOhFour: Page<Props> = ({ branch }) => {
   const { setBranchPreview } = useContext(PreviewContext)
   setBranchPreview(branch)
+  const [feedbackUrl, setFeedbackUrl] = useState<string>('')
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setFeedbackUrl(getFeedbackURL(window.location.href))
+    }
+  }, [])
 
   return (
     <>
@@ -37,7 +45,7 @@ const FourOhFour: Page<Props> = ({ branch }) => {
             <Button sx={styles.button}>
               <Link
                 sx={styles.buttonLink}
-                href="https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=help.vtex.com&entry.1799503232="
+                href={feedbackUrl || getFeedbackURL()}
               >
                 CONTACT US
               </Link>

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -5,8 +5,9 @@ import { Box, Flex, Text, Button, Link } from '@vtex/brand-ui'
 import styles from 'styles/error-page'
 import fiveHundredImage from '../../public/images/500-illustration.png'
 import { GetStaticProps } from 'next'
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { PreviewContext } from 'utils/contexts/preview'
+import { getFeedbackURL } from 'utils/get-url'
 
 interface Props {
   branch: string
@@ -15,6 +16,13 @@ interface Props {
 const FiveHundredPage: Page<Props> = ({ branch }) => {
   const { setBranchPreview } = useContext(PreviewContext)
   setBranchPreview(branch)
+  const [feedbackUrl, setFeedbackUrl] = useState<string>('')
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setFeedbackUrl(getFeedbackURL(window.location.href))
+    }
+  }, [])
 
   return (
     <>
@@ -34,7 +42,7 @@ const FiveHundredPage: Page<Props> = ({ branch }) => {
             <Button sx={styles.button}>
               <Link
                 sx={styles.buttonLink}
-                href="https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=help.vtex.com&entry.1799503232="
+                href={feedbackUrl || getFeedbackURL()}
               >
                 CONTACT US
               </Link>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -98,7 +98,7 @@ export const updatesData = (intl: IntlShape) => {
   return data
 }
 
-export const feedbackSectionData = (intl: IntlShape) => {
+export const feedbackSectionData = (intl: IntlShape, currentUrl?: string) => {
   const data: DocDataElement[] = [
     {
       id: 'Feedback',
@@ -107,7 +107,7 @@ export const feedbackSectionData = (intl: IntlShape) => {
         id: 'landing_page_header_feedback.message',
       }),
       description: '',
-      link: getFeedbackURL(),
+      link: getFeedbackURL(currentUrl),
     },
   ]
 

--- a/src/utils/get-url.tsx
+++ b/src/utils/get-url.tsx
@@ -1,5 +1,6 @@
-export const getFeedbackURL = () => {
-  return `https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=help.vtex.com&entry.1799503232=`
+export const getFeedbackURL = (currentUrl?: string) => {
+  const encodedUrl = currentUrl ? encodeURIComponent(currentUrl) : ''
+  return `https://docs.google.com/forms/d/e/1FAIpQLSfmnotPvPjw-SjiE7lt2Nt3RQgNUe10ixXZmuO2v9enOJReoQ/viewform?entry.1972292648=help.vtex.com&entry.1799503232=${encodedUrl}`
 }
 
 export const getDeveloperPortalURL = () => {


### PR DESCRIPTION
## Summary
This PR enhances the feedback form functionality by including the current page URL in feedback form links. This provides better context when users submit feedback, allowing the team to understand which page the user was on.

## Changes
- Updated `getFeedbackURL()` function to accept an optional `currentUrl` parameter and encode it in the form URL
- Modified `feedbackSectionData()` to accept and pass the current URL
- Updated components (Header, Footer, Layout) to track and pass the current URL
- Updated error pages (404, 500) to include current URL in feedback links

## Why
This change improves the feedback collection process by automatically including the page context, making it easier to identify and address issues or suggestions related to specific pages.

## Files Affected
- `src/utils/get-url.tsx` - Core function update
- `src/utils/constants.ts` - Function signature update
- `src/components/footer/index.tsx` - Usage update
- `src/components/header/index.tsx` - Usage update
- `src/components/layout.tsx` - Usage update
- `src/pages/404.tsx` - Usage update
- `src/pages/500.tsx` - Usage update