### PR TITLE
fix: correct GTM container ID mismatch in layout

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -102,7 +102,7 @@ export default function Layout({
 					new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 					j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 					'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-					})(window,document,'script','dataLayer','GTM-KZ58QQP5')
+					})(window,document,'script','dataLayer','GTM-K2NM75K')
 					`}
           </Script>
         </div>


### PR DESCRIPTION
## Summary
Fixed a mismatch between the GTM iframe and script initialization that was preventing GTM preview from working correctly.

## What Changed
- Updated GTM script initialization to use `GTM-K2NM75K` instead of `GTM-KZ58QQP5`
- The iframe was already using `GTM-K2NM75K`, but the script was initializing a different container
- This mismatch occurred after migrating from the temporary portal container to the old portal container to preserve GA data history

## Why
After portal migration, the code was updated to use the old portal's GTM container (`GTM-K2NM75K`) to maintain GA data continuity. However, the script initialization was not updated, causing GTM preview to fail. The preview would only work when manually selecting the old temporary container (`GTM-KZ58QQP5`).

## Files Affected
- `src/components/layout.tsx` - Updated GTM script container ID on line 105

## Testing
- GTM preview should now correctly detect and show events for `GTM-K2NM75K`
- GA tracking should continue working as before