### PR TITLE
feat: add GTM event tracking for copy link button

### DIFF
--- a/src/components/copy-link-button/index.tsx
+++ b/src/components/copy-link-button/index.tsx
@@ -15,6 +15,17 @@ export default function CopyLinkButton() {
     navigator.clipboard.writeText(window.location.href)
     setTooltipText(intl.formatMessage({ id: 'copy_link_button.tooltip' }))
 
+    // Push GTM event
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const win = window as any
+    if (typeof window !== 'undefined' && win.dataLayer) {
+      win.dataLayer.push({
+        event: 'copy_link_button_click',
+        page_url: window.location.href,
+        page_name: document.title,
+      })
+    }
+
     setTimeout(() => {
       setTooltipText(intl.formatMessage({ id: 'copy_link_button.text' }))
     }, 2000)


### PR DESCRIPTION
## Summary

Adds Google Tag Manager (GTM) event tracking to the copy link button component.

## Changes

- Push `copy_link_button_click` event to GTM dataLayer when button is clicked
- Include `page_url` and `page_name` in the event payload

## Why

Enable analytics tracking for copy link button usage to measure user engagement.
