### PR TITLE
chore: add and fix documentation redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -100,3 +100,9 @@ force = true
 from = "/faq/por-que-o-produto-nao-aparece-no-site--frequentlyAskedQuestions_382"
 status = 308
 to = "/pt/faq/por-que-o-produto-nao-aparece-no-site"
+
+[[redirects]]
+force = true
+from = "/pt/faq/por-que-o-produto-nao-aparece-no-site--frequentlyAskedQuestions_382"
+status = 308
+to = "/pt/faq/por-que-o-produto-nao-aparece-no-site"

--- a/public/redirects.json
+++ b/public/redirects.json
@@ -17652,10 +17652,6 @@
         "to": "/en/docs/tutorials/adding-or-editing-products"
       },
       {
-        "from": "/pt/faq/por-que-o-produto-nao-aparece-no-site--frequentlyAskedQuestions_382",
-        "to": "/pt/faq/por-que-o-produto-nao-aparece-no-site"
-      },
-      {
         "from": "/en/docs/tutorials/what-is-vtex-io",
         "to": "https://developers.vtex.com/docs/guides/vtex-io-documentation-what-is-vtex-io"
       }


### PR DESCRIPTION
## Summary

Adds and fixes URL redirects for documentation pages across multiple languages.

## Changes

### Product Tutorial Redirects
- Added redirect for Portuguese: `/tutorials/criar-um-produto-beta` → `/pt/docs/tutorials/adicionar-ou-editar-produto`
- Added redirect for Spanish: `/tutorials/agregar-producto-beta` → `/es/docs/tutorials/agregar-o-editar-productos`
- Added redirect for English: `/tutorials/adding-products-beta` → `/en/docs/tutorials/adding-or-editing-products`

### FAQ Redirect
- Added redirect for Portuguese FAQ: `/pt/faq/por-que-o-produto-nao-aparece-no-site--frequentlyAskedQuestions_382` → `/pt/faq/por-que-o-produto-nao-aparece-no-site`

### External Redirect
- Added redirect for VTEX IO tutorial to developers portal: `/en/docs/tutorials/what-is-vtex-io` → `https://developers.vtex.com/docs/guides/vtex-io-documentation-what-is-vtex-io`

## Why

These redirects ensure users accessing old or malformed URLs are properly redirected to the correct documentation pages.
