### PR TITLE
EDU-17416 feat: add card to category page

### DIFF
--- a/src/components/article-index/index.tsx
+++ b/src/components/article-index/index.tsx
@@ -43,8 +43,10 @@ const ArticleIndexing = ({ ...props }) => {
                   <Flex sx={styles.linksContainer}>
                     {props?.children?.map(
                       (el: { slug: string; name: string }) => (
-                        <Link href={el.slug} key={el.slug}>
-                          {el.name || 'Untitled'}
+                        <Link href={el.slug} key={el.slug} sx={styles.cardItem}>
+                          <Text sx={{ fontWeight: 'medium', fontSize: '16px' }}>
+                            {el.name || 'Untitled'}
+                          </Text>
                         </Link>
                       )
                     )}

--- a/src/components/article-index/index.tsx
+++ b/src/components/article-index/index.tsx
@@ -19,7 +19,7 @@ const ArticleIndexing = ({ ...props }) => {
       </Head>
       <Flex sx={styles.innerContainer}>
         <Box sx={styles.articleBox}>
-          <Box sx={styles.contentContainer}>
+          <Box sx={styles.articleIndexContentContainer}>
             <Flex sx={{ justifyContent: 'space-between' }}>
               {props.breadcrumbList.length > 0 && (
                 <Breadcrumb breadcrumbList={props.breadcrumbList} />
@@ -42,11 +42,20 @@ const ArticleIndexing = ({ ...props }) => {
                   </Text>
                   <Flex sx={styles.linksContainer}>
                     {props?.children?.map(
-                      (el: { slug: string; name: string }) => (
+                      (el: {
+                        slug: string
+                        name: string
+                        excerpt?: string
+                      }) => (
                         <Link href={el.slug} key={el.slug} sx={styles.cardItem}>
                           <Text sx={{ fontWeight: 'medium', fontSize: '16px' }}>
                             {el.name || 'Untitled'}
                           </Text>
+                          {el.excerpt && (
+                            <Text sx={styles.cardItemExcerpt}>
+                              {el.excerpt}
+                            </Text>
+                          )}
                         </Link>
                       )
                     )}

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -178,15 +178,32 @@ const titleContainer: SxStyleProp = {
 }
 
 const linksContainer: SxStyleProp = {
-  flexDirection: 'column',
-  pl: '16px',
+  flexWrap: 'wrap',
   gap: '16px',
   mt: '32px',
-  borderLeft: '3px solid #E7E9EE',
+}
+
+const cardItem: SxStyleProp = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
+  padding: '16px 20px',
+  border: '1px solid #E7E9EE',
+  borderRadius: '8px',
+  cursor: 'pointer',
+  width: ['100%', '100%', 'calc(50% - 8px)'],
+  color: 'muted.0',
+  textDecoration: 'none',
+  ':hover': {
+    backgroundColor: '#F8F7FC',
+    borderColor: '#C0C8D2',
+  },
 }
 
 export default {
   linksContainer,
+  cardItem,
   titleContainer,
   textContainer,
   indexContainer,

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -89,6 +89,11 @@ const contentContainer: SxStyleProp = {
   minWidth: ['0px', '470px', '470px'],
 }
 
+const articleIndexContentContainer: SxStyleProp = {
+  ...contentContainer,
+  maxWidth: ['100%', '100%', '100%', '100%', '720px', '720px', '720px'],
+}
+
 const documentationTitle: SxStyleProp = {
   marginTop: '16px',
   fontSize: '1.75em',
@@ -192,7 +197,15 @@ const cardItem: SxStyleProp = {
   border: '1px solid #E7E9EE',
   borderRadius: '8px',
   cursor: 'pointer',
-  width: ['100%', '100%', 'calc(50% - 8px)'],
+  width: [
+    '100%',
+    '100%',
+    'calc(50% - 8px)',
+    'calc(50% - 8px)',
+    'calc(50% - 8px)',
+    'calc(50% - 8px)',
+    'calc(50% - 8px)',
+  ],
   color: 'muted.0',
   textDecoration: 'none',
   ':hover': {
@@ -201,9 +214,18 @@ const cardItem: SxStyleProp = {
   },
 }
 
+const cardItemExcerpt: SxStyleProp = {
+  mt: '6px',
+  fontSize: '14px',
+  lineHeight: '20px',
+  color: 'muted.1',
+}
+
 export default {
   linksContainer,
   cardItem,
+  cardItemExcerpt,
+  articleIndexContentContainer,
   titleContainer,
   textContainer,
   indexContainer,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change the category page from listing subcategories and articles in a list to displaying them as cards

#### What problem is this solving?

Improve portal layout

#### How should this be manually tested?

#### Screenshots or example usage
<img width="1207" height="802" alt="Screenshot 2026-04-10 at 14 35 30" src="https://github.com/user-attachments/assets/dbd3268e-8825-403a-8b14-44022696fe04" />

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
