### PR TITLE
EDU-17784 - Redirect VTEX CX Platform docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -471,34 +471,34 @@ to = "/pt/docs/tutorials/configurar-o-dominio-da-loja"
 force = true
 from = "/en/docs/tutorials/weni-by-vtex/agent-builder/official-agents-from-weni-by-vtex"
 status = 308
-to = "/en/docs/tutorials/vtex-agentic-cx-platform/agent-builder/official-agents-from-vtex-agentic-cx-platform"
+to = "/en/docs/tutorials/vtex-cx-platform/agent-builder/official-agents-from-vtex-agentic-cx-platform"
 
 [[redirects]]
 force = true
 from = "/en/docs/tutorials/weni-by-vtex/agent-builder/assigning-and-testing-agents"
 status = 308
-to = "/en/docs/tutorials/vtex-agentic-cx-platform/agent-builder/assigning-and-testing-agents-in-agent-builder"
+to = "/en/docs/tutorials/vtex-cx-platform/agent-builder/assigning-and-testing-agents-in-agent-builder"
 
 [[redirects]]
 force = true
 from = "/en/docs/tutorials/weni-by-vtex/flows/flows-introduction"
 status = 308
-to = "/en/docs/tutorials/vtex-agentic-cx-platform/agent-builder/automation-flow/automation-flow-overview"
+to = "/en/docs/tutorials/vtex-cx-platform/agent-builder/automation-flow/automation-flow-overview"
 
 [[redirects]]
 force = true
 from = "/en/docs/tutorials/weni-by-vtex/weni-settings/weni-chats-setting-up-human-attendance"
 status = 308
-to = "/en/docs/tutorials/vtex-agentic-cx-platform/live-desk/manage-live-desk"
+to = "/en/docs/tutorials/vtex-cx-platform/live-desk/manage-live-desk"
 
 [[redirects]]
 force = true
 from = "/en/docs/tutorials/weni-by-vtex/chats/weni-chats-human-service-dashboard"
 status = 308
-to = "/en/docs/tutorials/vtex-agentic-cx-platform/live-desk/agentic-cx-live-desk-dashboard"
+to = "/en/docs/tutorials/vtex-cx-platform/live-desk/vtex-cx-live-desk-dashboard"
 
 [[redirects]]
 force = true
 from = "/en/docs/tutorials/weni-by-vtex/chats/introduction-to-the-chats-module"
 status = 308
-to = "/en/docs/tutorials/vtex-agentic-cx-platform/live-desk/agentic-cx-live-desk-overview"
+to = "/en/docs/tutorials/vtex-cx-platform/live-desk/vtex-cx-live-desk-overview"

--- a/netlify.toml
+++ b/netlify.toml
@@ -469,9 +469,75 @@ to = "/pt/docs/tutorials/configurar-o-dominio-da-loja"
 
 [[redirects]]
 force = true
-from = "/en/docs/tutorials/weni-by-vtex/agent-builder/official-agents-from-weni-by-vtex"
+from = "/en/docs/tutorials/weni-by-vtex-category"
 status = 308
-to = "/en/docs/tutorials/vtex-cx-platform/agent-builder/official-agents-from-vtex-agentic-cx-platform"
+to = "/en/docs/tutorials/vtex-cx-platform-category"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex-category"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform-category"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex-category"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform-category"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/chats-category"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/live-desk-category"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex/chats-category"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform/live-desk-category"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/chats-category"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/live-desk-category"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/weni-by-vtex-overview-category"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/vtex-cx-platform-overview-category"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex/weni-by-vtex-overview-category"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform/vtex-cx-platform-overview-category"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/weni-by-vtex-overview-category"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/vtex-cx-platform-overview-category"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/insights-category"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/vtex-cx-platform-analytics"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex/insights-category"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform/vtex-cx-platform-analytics"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/insights-category"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/vtex-cx-platform-analytics"
 
 [[redirects]]
 force = true
@@ -481,24 +547,121 @@ to = "/en/docs/tutorials/vtex-cx-platform/agent-builder/assigning-and-testing-ag
 
 [[redirects]]
 force = true
-from = "/en/docs/tutorials/weni-by-vtex/flows/flows-introduction"
+from = "/en/docs/tutorials/weni-by-vtex/agent-builder/official-agents-from-weni-by-vtex"
 status = 308
-to = "/en/docs/tutorials/vtex-cx-platform/agent-builder/automation-flow/automation-flow-overview"
-
-[[redirects]]
-force = true
-from = "/en/docs/tutorials/weni-by-vtex/weni-settings/weni-chats-setting-up-human-attendance"
-status = 308
-to = "/en/docs/tutorials/vtex-cx-platform/live-desk/manage-live-desk"
-
-[[redirects]]
-force = true
-from = "/en/docs/tutorials/weni-by-vtex/chats/weni-chats-human-service-dashboard"
-status = 308
-to = "/en/docs/tutorials/vtex-cx-platform/live-desk/vtex-cx-live-desk-dashboard"
+to = "/en/docs/tutorials/vtex-cx-platform/agent-builder/official-agents-from-vtex-cx-platform"
 
 [[redirects]]
 force = true
 from = "/en/docs/tutorials/weni-by-vtex/chats/introduction-to-the-chats-module"
 status = 308
-to = "/en/docs/tutorials/vtex-cx-platform/live-desk/vtex-cx-live-desk-overview"
+to = "/en/docs/tutorials/vtex-cx-platform/live-desk/introduction-to-live-desk"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/chats/weni-chats-human-service-dashboard"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/live-desk/vtex-cx-platform-live-desk-dashboard"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/flows/flows-introduction"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/agent-builder/flows/automation-flow-overview"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/insights/insights"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/vtex-cx-platform-analytics"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/integrations/whatsapp-weni-express-integration"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/integrations/whatsapp-vtex-cx-platform-express-integration"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/weni-by-vtex-overview/changing-the-platform-language"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/vtex-cx-platform-overview/vtex-cx-platform-overview"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/weni-by-vtex-overview/weni-permission-system"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/vtex-cx-platform-overview/vtex-cx-platform-permission-system"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/weni-settings/weni-chats-setting-up-human-attendance"
+status = 308
+to = "/en/docs/tutorials/vtex-cx-platform/vtex-cx-platform-settings/manage-live-desk"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/agent-builder/agentes-oficiales-de-weni-by-vtex"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/agent-builder/agentes-oficiales-de-vtex-cx-platform"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/chats/weni-chats-dashboard-de-atencion-humana"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/live-desk/dashboard-de-live-desk"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/weni-settings/weni-chats-configurando-el-atencion-humana"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/vtex-cx-platform-settings/configurar-el-live-desk"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/insights/insights"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/vtex-cx-platform-analytics"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/integrations/canal-weni-web-chat"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/integrations/canal-web-chat"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/weni-by-vtex/integrations/whatsapp-integracion-express-weni"
+status = 308
+to = "/es/docs/tutorials/vtex-cx-platform/integrations/whatsapp-integracion-express-con-vtex-cx-platform"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex/agent-builder/agentes-oficiais-da-weni-by-vtex"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform/agent-builder/agentes-oficiais-da-vtex-cx-platform"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex/chats/introducao-sobre-o-modulo-de-chats"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform/live-desk/visao-geral-do-live-desk-agentic-cx"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex/chats/weni-chats-dashboard-de-atendimento-humano"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform/live-desk/dashboard-do-live-desk"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex/flows/introducao-a-fluxos"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform/agent-builder/flows/visao-geral-fluxo-de-automacao"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/weni-by-vtex/insights/insights-dashboard-de-atendimento-humano"
+status = 308
+to = "/pt/docs/tutorials/vtex-cx-platform/vtex-cx-platform-analytics"
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -466,3 +466,39 @@ force = true
 from = "/pt/docs/tutorials/configurando-dominios-no-gerenciamento-da-conta"
 status = 308
 to = "/pt/docs/tutorials/configurar-o-dominio-da-loja"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/agent-builder/official-agents-from-weni-by-vtex"
+status = 308
+to = "/en/docs/tutorials/vtex-agentic-cx-platform/agent-builder/official-agents-from-vtex-agentic-cx-platform"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/agent-builder/assigning-and-testing-agents"
+status = 308
+to = "/en/docs/tutorials/vtex-agentic-cx-platform/agent-builder/assigning-and-testing-agents-in-agent-builder"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/flows/flows-introduction"
+status = 308
+to = "/en/docs/tutorials/vtex-agentic-cx-platform/agent-builder/automation-flow/automation-flow-overview"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/weni-settings/weni-chats-setting-up-human-attendance"
+status = 308
+to = "/en/docs/tutorials/vtex-agentic-cx-platform/live-desk/manage-live-desk"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/chats/weni-chats-human-service-dashboard"
+status = 308
+to = "/en/docs/tutorials/vtex-agentic-cx-platform/live-desk/agentic-cx-live-desk-dashboard"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/weni-by-vtex/chats/introduction-to-the-chats-module"
+status = 308
+to = "/en/docs/tutorials/vtex-agentic-cx-platform/live-desk/agentic-cx-live-desk-overview"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Redirect old Weni docs to VTEX CX Platform. Refers to [EDU-17784](https://vtex-dev.atlassian.net/browse/EDU-17784).

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
