### PR TITLE
EDU-17648: Add redirects for relocated abandoned cart articles

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -466,3 +466,15 @@ force = true
 from = "/pt/docs/tutorials/configurando-dominios-no-gerenciamento-da-conta"
 status = 308
 to = "/pt/docs/tutorials/configurar-o-dominio-da-loja"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/acesse-o-carrinho-abandonado-dos-clientes"
+status = 308
+to = "/pt/docs/tutorials/acessar-o-carrinho-abandonado-dos-clientes"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/acceda-al-carrito-abandonado-de-los-clientes"
+status = 308
+to = "/es/docs/tutorials/acceder-al-carrito-abandonado-de-los-clientes"


### PR DESCRIPTION
Added redirects for the renamed "Accessing a Client's Abandoned Cart" article.

## Related Task

[EDU-17648](https://vtex-dev.atlassian.net/browse/EDU-17648)
