### PR TITLE
EDU-17909 | Implement improvements to the search components

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@code-hike/mdx": "^0.9.0",
     "@fortawesome/fontawesome-free": "^6.6.0",
-    "@img/sharp-linux-x64": "^0.33.5",
     "@octokit/types": "^14.1.0",
     "@plaiceholder/next": "^2.5.0",
     "@types/http-proxy": "^1.17.9",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,9 @@
     "typescript": "^4.6.2",
     "vitest": "^4.1.0"
   },
+  "optionalDependencies": {
+    "@img/sharp-linux-x64": "^0.33.5"
+  },
   "overrides": {
     "next-plugin-preval": {
       "next": "$next"

--- a/src/components/newsletter-section/index.tsx
+++ b/src/components/newsletter-section/index.tsx
@@ -24,7 +24,7 @@ const NewsletterSection = () => {
             alt="Image of the VTEX store environment"
             priority
             fill
-            objectFit="cover"
+            style={{ objectFit: 'cover' }}
           />
         </Box>
         {/* Mobile Image */}
@@ -34,7 +34,7 @@ const NewsletterSection = () => {
             alt="Image of the VTEX store environment"
             priority
             fill
-            objectFit="cover"
+            style={{ objectFit: 'cover' }}
           />
         </Box>
       </Box>

--- a/src/pages/announcements/index.tsx
+++ b/src/pages/announcements/index.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@vtex/brand-ui'
+import { Box, Flex } from '@vtex/brand-ui'
 import { GetStaticProps, NextPage } from 'next'
 
 import { AnnouncementDataElement } from 'utils/typings/types'
@@ -30,6 +30,12 @@ import { SearchIcon } from '@vtexdocs/components'
 import { Input } from '@vtexdocs/components'
 import { getISRRevalidateTime } from 'utils/config'
 import { fetchBatch, parseFrontmatter } from 'utils/fetchBatchGithubData'
+import Tooltip from 'components/tooltip'
+import {
+  countTermMatches,
+  getSearchTerms,
+  itemMatchesAnyTerm,
+} from 'utils/search/tokenizedSearch'
 
 interface Props {
   announcementsData: AnnouncementDataElement[]
@@ -46,6 +52,10 @@ const AnnouncementsPage: NextPage<Props> = ({ announcementsData, branch }) => {
 
   const itemsPerPage = 8
   const [searchTerm, setSearchTerm] = useState('')
+  const searchTerms = useMemo(
+    () => getSearchTerms(searchTerm, intl.locale),
+    [searchTerm, intl.locale]
+  )
   const [page, setPage] = useState({
     curr: 1,
     total: Math.ceil(announcementsData.length / itemsPerPage),
@@ -60,9 +70,13 @@ const AnnouncementsPage: NextPage<Props> = ({ announcementsData, branch }) => {
 
   const filteredResult = useMemo(() => {
     const data = announcementsData.filter((announcement) => {
-      const matchesSearch = announcement.title
-        ?.toLowerCase()
-        .includes(searchTerm.toLowerCase())
+      const fields = [
+        announcement.title ?? '',
+        announcement.synopsis ?? '',
+        announcement.tags.length > 0 ? announcement.tags.join(' ') : '',
+      ].map((s) => String(s).toLowerCase())
+
+      const matchesSearch = itemMatchesAnyTerm(searchTerms, fields)
 
       const matchesType =
         filters.type.length === 0 ||
@@ -75,12 +89,25 @@ const AnnouncementsPage: NextPage<Props> = ({ announcementsData, branch }) => {
       return matchesSearch && matchesType && matchesArea
     })
 
-    data.sort((a, b) => {
+    return data.sort((a, b) => {
+      const fieldsA = [
+        a.title ?? '',
+        a.synopsis ?? '',
+        a.tags.length > 0 ? a.tags.join(' ') : '',
+      ].map((s) => String(s).toLowerCase())
+      const fieldsB = [
+        b.title ?? '',
+        b.synopsis ?? '',
+        b.tags.length > 0 ? b.tags.join(' ') : '',
+      ].map((s) => String(s).toLowerCase())
+      const matchA = countTermMatches(searchTerms, fieldsA)
+      const matchB = countTermMatches(searchTerms, fieldsB)
+      if (matchA !== matchB) {
+        return matchB - matchA
+      }
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     })
-
-    return data
-  }, [searchTerm, filters, intl.locale])
+  }, [searchTerms, filters, announcementsData])
 
   useEffect(() => {
     setPage({
@@ -144,14 +171,53 @@ const AnnouncementsPage: NextPage<Props> = ({ announcementsData, branch }) => {
               }
             />
           </Flex>
-          <Input
-            placeholder={intl.formatMessage({
-              id: 'announcements_page_search.placeholder',
-            })}
-            Icon={SearchIcon}
-            value={searchTerm}
-            onChange={(value) => setSearchTerm(value)}
-          />
+          <Flex sx={{ width: '100%', alignItems: 'center', gap: '8px' }}>
+            <Box sx={{ width: '100%' }}>
+              <Input
+                placeholder={intl.formatMessage({
+                  id: 'announcements_page_search.placeholder',
+                })}
+                Icon={SearchIcon}
+                value={searchTerm}
+                onChange={(value) => setSearchTerm(value)}
+              />
+            </Box>
+            <Tooltip
+              placement="top"
+              label={intl.formatMessage({
+                id: 'known_issues_page_search.priority_tooltip',
+                defaultMessage:
+                  'Resultados priorizam titulos com maior quantidade de termos correspondentes; em empate, aplica-se a ordenacao por data de criacao.',
+              })}
+            >
+              <Box
+                as="button"
+                type="button"
+                aria-label={intl.formatMessage({
+                  id: 'known_issues_page_search.priority_tooltip',
+                })}
+                sx={{
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  display: 'flex',
+                  width: '24px',
+                  height: '24px',
+                  borderRadius: '50%',
+                  border: '1px solid',
+                  borderColor: 'muted.2',
+                  backgroundColor: 'transparent',
+                  color: 'muted.0',
+                  fontSize: '12px',
+                  fontWeight: 700,
+                  cursor: 'help',
+                  flexShrink: 0,
+                  p: 0,
+                }}
+              >
+                ?
+              </Box>
+            </Tooltip>
+          </Flex>
           <Flex sx={styles.cardContainer}>
             {paginatedResult.length === 0 && (
               <Flex sx={styles.noResults}>

--- a/src/pages/faq/index.tsx
+++ b/src/pages/faq/index.tsx
@@ -30,6 +30,12 @@ import { SearchIcon } from '@vtexdocs/components'
 import ChipFilter from 'components/chip-filter'
 import { getISRRevalidateTime } from 'utils/config'
 import { fetchBatch, parseFrontmatter } from 'utils/fetchBatchGithubData'
+import Tooltip from 'components/tooltip'
+import {
+  countTermMatches,
+  getSearchTerms,
+  itemMatchesAnyTerm,
+} from 'utils/search/tokenizedSearch'
 
 interface Props {
   faqData: FaqCardDataElement[]
@@ -45,7 +51,10 @@ const FaqPage: NextPage<Props> = ({ faqData, branch }) => {
   const [filters, setFilters] = useState<string[]>([])
   const [search, setSearch] = useState<string>('')
   const [sortByValue, setSortByValue] = useState<SortByType>('newest')
-  const normalizedSearch = useMemo(() => search.toLowerCase(), [search])
+  const searchTerms = useMemo(
+    () => getSearchTerms(search, intl.locale),
+    [search, intl.locale]
+  )
 
   const chipCategories: string[] = faqFilter(intl).options.map(
     (option) => option.name
@@ -55,14 +64,28 @@ const FaqPage: NextPage<Props> = ({ faqData, branch }) => {
     const data = faqData.filter((question) => {
       const hasFilter: boolean =
         filters.length === 0 || filters.includes(question.productTeam)
-      const hasSearch: boolean = question.title
-        .toLowerCase()
-        .includes(normalizedSearch)
+      const fields = [question.title, question.slug, question.productTeam].map(
+        (s) => String(s ?? '').toLowerCase()
+      )
+      const hasSearch = itemMatchesAnyTerm(searchTerms, fields)
 
       return hasFilter && hasSearch
     })
 
     const sorted = data.sort((a, b) => {
+      const fieldsA = [a.title, a.slug, a.productTeam].map((s) =>
+        String(s ?? '').toLowerCase()
+      )
+      const fieldsB = [b.title, b.slug, b.productTeam].map((s) =>
+        String(s ?? '').toLowerCase()
+      )
+      const matchCountA = countTermMatches(searchTerms, fieldsA)
+      const matchCountB = countTermMatches(searchTerms, fieldsB)
+
+      if (matchCountA !== matchCountB) {
+        return matchCountB - matchCountA
+      }
+
       const dateA =
         sortByValue === 'newest' ? new Date(b.createdAt) : new Date(b.updatedAt)
       const dateB =
@@ -72,7 +95,7 @@ const FaqPage: NextPage<Props> = ({ faqData, branch }) => {
     })
 
     return sorted
-  }, [filters, sortByValue, intl.locale, normalizedSearch])
+  }, [filters, sortByValue, searchTerms, faqData])
 
   useEffect(() => {
     setPageIndex({
@@ -112,7 +135,10 @@ const FaqPage: NextPage<Props> = ({ faqData, branch }) => {
   function getCategoryAmount(category: string): number {
     return faqData.filter((data) => {
       const matchesCategory = data.productTeam === category
-      const matchesSearch = data.title.toLowerCase().includes(normalizedSearch)
+      const fields = [data.title, data.slug, data.productTeam].map((s) =>
+        String(s ?? '').toLowerCase()
+      )
+      const matchesSearch = itemMatchesAnyTerm(searchTerms, fields)
       return matchesCategory && matchesSearch
     }).length
   }
@@ -163,14 +189,53 @@ const FaqPage: NextPage<Props> = ({ faqData, branch }) => {
               onSelect={(ordering) => setSortByValue(ordering as SortByType)}
             />
           </Flex>
-          <Input
-            Icon={SearchIcon}
-            placeholder={intl.formatMessage({
-              id: 'faq_page_search.placeholder',
-            })}
-            value={search}
-            onChange={(value: string) => setSearch(value)}
-          />
+          <Flex sx={{ width: '100%', alignItems: 'center', gap: '8px' }}>
+            <Box sx={{ width: '100%' }}>
+              <Input
+                Icon={SearchIcon}
+                placeholder={intl.formatMessage({
+                  id: 'faq_page_search.placeholder',
+                })}
+                value={search}
+                onChange={(value: string) => setSearch(value)}
+              />
+            </Box>
+            <Tooltip
+              placement="top"
+              label={intl.formatMessage({
+                id: 'known_issues_page_search.priority_tooltip',
+                defaultMessage:
+                  'Resultados priorizam titulos com maior quantidade de termos correspondentes; em empate, aplica-se a ordenacao selecionada.',
+              })}
+            >
+              <Box
+                as="button"
+                type="button"
+                aria-label={intl.formatMessage({
+                  id: 'known_issues_page_search.priority_tooltip',
+                })}
+                sx={{
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  display: 'flex',
+                  width: '24px',
+                  height: '24px',
+                  borderRadius: '50%',
+                  border: '1px solid',
+                  borderColor: 'muted.2',
+                  backgroundColor: 'transparent',
+                  color: 'muted.0',
+                  fontSize: '12px',
+                  fontWeight: 700,
+                  cursor: 'help',
+                  flexShrink: 0,
+                  p: 0,
+                }}
+              >
+                ?
+              </Box>
+            </Tooltip>
+          </Flex>
           <ChipFilter
             removeCategory={handleFilterRemoval}
             resetFilters={handleFilterReset}

--- a/src/pages/known-issues/index.tsx
+++ b/src/pages/known-issues/index.tsx
@@ -38,6 +38,11 @@ import { SearchIcon } from '@vtexdocs/components'
 import { getISRRevalidateTime } from 'utils/config'
 import { fetchBatch, parseFrontmatter } from 'utils/fetchBatchGithubData'
 import Tooltip from 'components/tooltip'
+import {
+  countTermMatches,
+  getSearchTerms,
+  itemMatchesAnyTerm,
+} from 'utils/search/tokenizedSearch'
 
 interface Props {
   knownIssuesData: KnownIssueDataElement[]
@@ -67,84 +72,9 @@ const KnownIssuesPage: NextPage<Props> = ({ knownIssuesData, branch }) => {
   }>({ kiStatus: [], modules: [] })
   const [search, setSearch] = useState<string>('')
   const [sortByValue, setSortByValue] = useState<SortByType>('newest')
-  const normalizedSearch = useMemo(() => search.toLowerCase(), [search])
-  const searchStopwords = useMemo(() => {
-    const stopwordsByLocale: Record<string, Set<string>> = {
-      pt: new Set([
-        'a',
-        'ao',
-        'aos',
-        'as',
-        'Ã ',
-        'Ã s',
-        'com',
-        'da',
-        'das',
-        'de',
-        'do',
-        'dos',
-        'e',
-        'em',
-        'na',
-        'nas',
-        'no',
-        'nos',
-        'ou',
-        'para',
-        'por',
-        'sem',
-      ]),
-      en: new Set([
-        'a',
-        'an',
-        'and',
-        'as',
-        'at',
-        'by',
-        'for',
-        'from',
-        'in',
-        'is',
-        'of',
-        'on',
-        'or',
-        'the',
-        'to',
-        'with',
-        'it',
-      ]),
-      es: new Set([
-        'a',
-        'al',
-        'con',
-        'de',
-        'del',
-        'el',
-        'en',
-        'es',
-        'la',
-        'las',
-        'los',
-        'o',
-        'para',
-        'por',
-        'un',
-        'una',
-        'y',
-        'lo',
-      ]),
-    }
-    const localeKey = (intl.locale ?? 'pt').split('-')[0]
-    return stopwordsByLocale[localeKey] ?? stopwordsByLocale.pt
-  }, [intl.locale])
   const searchTerms = useMemo(
-    () =>
-      normalizedSearch
-        .replace(/["'\u201C\u201D\u2018\u2019]/g, ' ')
-        .trim()
-        .split(/\s+/)
-        .filter((term: string) => term && !searchStopwords.has(term)),
-    [normalizedSearch, searchStopwords]
+    () => getSearchTerms(search, intl.locale),
+    [search, intl.locale]
   )
 
   const statusConfig: FilterConfig = useMemo(
@@ -173,37 +103,18 @@ const KnownIssuesPage: NextPage<Props> = ({ knownIssuesData, branch }) => {
         (filters.modules.length === 0 ||
           filters.modules.includes(knownIssue.module))
 
-      const title = knownIssue.title.toLowerCase()
-      const id = knownIssue.id
-      const hasSearch: boolean =
-        searchTerms.length === 0 ||
-        searchTerms.some(
-          (term: string) => title.includes(term) || id.includes(term)
-        )
+      const fields = [knownIssue.title, knownIssue.id].map((s) =>
+        String(s ?? '').toLowerCase()
+      )
+      const hasSearch = itemMatchesAnyTerm(searchTerms, fields)
       return hasFilter && hasSearch
     })
 
     const sorted = data.sort((a, b) => {
-      const titleA = a.title.toLowerCase()
-      const titleB = b.title.toLowerCase()
-      const idA = a.id
-      const idB = b.id
-      const matchCountA =
-        searchTerms.length === 0
-          ? 0
-          : searchTerms.reduce(
-              (count: number, term: string) =>
-                count + (titleA.includes(term) || idA.includes(term) ? 1 : 0),
-              0
-            )
-      const matchCountB =
-        searchTerms.length === 0
-          ? 0
-          : searchTerms.reduce(
-              (count: number, term: string) =>
-                count + (titleB.includes(term) || idB.includes(term) ? 1 : 0),
-              0
-            )
+      const fieldsA = [a.title, a.id].map((s) => String(s ?? '').toLowerCase())
+      const fieldsB = [b.title, b.id].map((s) => String(s ?? '').toLowerCase())
+      const matchCountA = countTermMatches(searchTerms, fieldsA)
+      const matchCountB = countTermMatches(searchTerms, fieldsB)
 
       if (matchCountA !== matchCountB) {
         return matchCountB - matchCountA

--- a/src/pages/troubleshooting/index.tsx
+++ b/src/pages/troubleshooting/index.tsx
@@ -4,12 +4,12 @@ import troubleshooting from '../../../public/images/troubleshooting.png'
 import Head from 'next/head'
 import { useIntl } from 'react-intl'
 import type { GetStaticPropsContext, NextPage } from 'next'
-import { useContext, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { PreviewContext } from 'utils/contexts/preview'
 import { getDocsPaths as getTroubleshootingPaths } from 'utils/getDocsPaths'
 import { getLogger } from 'utils/logging/log-util'
 import { LocaleType } from 'utils/typings/unionTypes'
-import { Flex } from '@vtex/brand-ui'
+import { Box, Flex } from '@vtex/brand-ui'
 import { TroubleshootingDataElement } from 'utils/typings/types'
 import usePagination from 'utils/hooks/usePagination'
 import TroubleshootingCard from 'components/troubleshooting-card'
@@ -21,6 +21,12 @@ import { Input } from '@vtexdocs/components'
 import { getISRRevalidateTime } from 'utils/config'
 import { fetchBatch } from 'utils/fetchBatchGithubData'
 import { parseFrontmatter } from 'utils/fetchBatchGithubData'
+import Tooltip from 'components/tooltip'
+import {
+  countTermMatches,
+  getSearchTerms,
+  itemMatchesAnyTerm,
+} from 'utils/search/tokenizedSearch'
 
 interface Props {
   branch: string
@@ -50,6 +56,10 @@ const TroubleshootingPage: NextPage<Props> = ({
     symptoms: string[]
   }>({ domains: [], symptoms: [] })
   const [search, setSearch] = useState<string>('')
+  const searchTerms = useMemo(
+    () => getSearchTerms(search, intl.locale),
+    [search, intl.locale]
+  )
 
   const createDynamicTroubleshootingFilter = (
     nameId: string,
@@ -73,16 +83,35 @@ const TroubleshootingPage: NextPage<Props> = ({
           (troubleshoot.symptomFilters ?? []).some((tag) =>
             filters.symptoms.includes(tag)
           ))
-      const hasSearch: boolean = troubleshoot.title
-        .toLowerCase()
-        .includes(search.toLowerCase())
+      const fields = [troubleshoot.title, troubleshoot.slug].map((s) =>
+        String(s ?? '').toLowerCase()
+      )
+      const hasSearch = itemMatchesAnyTerm(searchTerms, fields)
       return hasSearch && hasFilters
     })
 
-    setPageIndex({ curr: 1, total: Math.ceil(data.length / itemsPerPage) })
+    return data.sort((a, b) => {
+      const fieldsA = [a.title, a.slug].map((s) =>
+        String(s ?? '').toLowerCase()
+      )
+      const fieldsB = [b.title, b.slug].map((s) =>
+        String(s ?? '').toLowerCase()
+      )
+      const matchA = countTermMatches(searchTerms, fieldsA)
+      const matchB = countTermMatches(searchTerms, fieldsB)
+      if (matchA !== matchB) {
+        return matchB - matchA
+      }
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    })
+  }, [filters, searchTerms, troubleshootingData])
 
-    return data
-  }, [filters, intl.locale, search])
+  useEffect(() => {
+    setPageIndex({
+      curr: 1,
+      total: Math.ceil(filteredResult.length / itemsPerPage),
+    })
+  }, [filteredResult])
 
   const paginatedResult = usePagination<TroubleshootingDataElement>(
     itemsPerPage,
@@ -141,14 +170,53 @@ const TroubleshootingPage: NextPage<Props> = ({
               selectedTags={filters.symptoms}
             />
           </Flex>
-          <Input
-            placeholder={intl.formatMessage({
-              id: 'troubleshooting_page_search.placeholder',
-            })}
-            Icon={SearchIcon}
-            value={search}
-            onChange={(value: string) => setSearch(value)}
-          />
+          <Flex sx={{ width: '100%', alignItems: 'center', gap: '8px' }}>
+            <Box sx={{ width: '100%' }}>
+              <Input
+                placeholder={intl.formatMessage({
+                  id: 'troubleshooting_page_search.placeholder',
+                })}
+                Icon={SearchIcon}
+                value={search}
+                onChange={(value: string) => setSearch(value)}
+              />
+            </Box>
+            <Tooltip
+              placement="top"
+              label={intl.formatMessage({
+                id: 'known_issues_page_search.priority_tooltip',
+                defaultMessage:
+                  'Resultados priorizam titulos com maior quantidade de termos correspondentes; em empate, aplica-se a ordenacao por data de atualizacao.',
+              })}
+            >
+              <Box
+                as="button"
+                type="button"
+                aria-label={intl.formatMessage({
+                  id: 'known_issues_page_search.priority_tooltip',
+                })}
+                sx={{
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  display: 'flex',
+                  width: '24px',
+                  height: '24px',
+                  borderRadius: '50%',
+                  border: '1px solid',
+                  borderColor: 'muted.2',
+                  backgroundColor: 'transparent',
+                  color: 'muted.0',
+                  fontSize: '12px',
+                  fontWeight: 700,
+                  cursor: 'help',
+                  flexShrink: 0,
+                  p: 0,
+                }}
+              >
+                ?
+              </Box>
+            </Tooltip>
+          </Flex>
           <Flex sx={styles.cardContainer}>
             {paginatedResult.length === 0 && (
               <Flex sx={styles.noResults}>

--- a/src/tests/cypress/plugins/index.mjs
+++ b/src/tests/cypress/plugins/index.mjs
@@ -1,6 +1,5 @@
 /// <reference types="cypress" />
 import clipboardy from 'clipboardy'
-import { unlink } from 'fs'
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins
 //

--- a/src/utils/search/tokenizedSearch.ts
+++ b/src/utils/search/tokenizedSearch.ts
@@ -1,0 +1,104 @@
+/** Stopwords por idioma base (pt/en/es), alinhado à busca de Known Issues. */
+export const STOPWORDS_BY_LOCALE: Record<string, Set<string>> = {
+  pt: new Set([
+    'a',
+    'ao',
+    'aos',
+    'as',
+    'à',
+    'às',
+    'com',
+    'da',
+    'das',
+    'de',
+    'do',
+    'dos',
+    'e',
+    'em',
+    'na',
+    'nas',
+    'no',
+    'nos',
+    'ou',
+    'para',
+    'por',
+    'sem',
+  ]),
+  en: new Set([
+    'a',
+    'an',
+    'and',
+    'as',
+    'at',
+    'by',
+    'for',
+    'from',
+    'in',
+    'is',
+    'of',
+    'on',
+    'or',
+    'the',
+    'to',
+    'with',
+    'it',
+  ]),
+  es: new Set([
+    'a',
+    'al',
+    'con',
+    'de',
+    'del',
+    'el',
+    'en',
+    'es',
+    'la',
+    'las',
+    'los',
+    'o',
+    'para',
+    'por',
+    'un',
+    'una',
+    'y',
+    'lo',
+  ]),
+}
+
+export function getStopwordSet(locale: string): Set<string> {
+  const localeKey = (locale ?? 'pt').split('-')[0]
+  return STOPWORDS_BY_LOCALE[localeKey] ?? STOPWORDS_BY_LOCALE.pt
+}
+
+/**
+ * Normaliza a busca, remove aspas tipográficas, divide em termos e remove stopwords.
+ */
+export function getSearchTerms(rawSearch: string, locale: string): string[] {
+  const normalized = rawSearch.toLowerCase()
+  const stopwords = getStopwordSet(locale)
+  return normalized
+    .replace(/["'\u201C\u201D\u2018\u2019]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter((term) => term && !stopwords.has(term))
+}
+
+/** `fields` devem estar em minúsculas. */
+export function termMatchesInFields(term: string, fields: string[]): boolean {
+  return fields.some((field) => field.includes(term))
+}
+
+/** Equivalente ao hasSearch de Known Issues: sem termos = tudo passa; senão basta um termo bater em qualquer campo. */
+export function itemMatchesAnyTerm(terms: string[], fields: string[]): boolean {
+  if (terms.length === 0) return true
+  return terms.some((term) => termMatchesInFields(term, fields))
+}
+
+/** Conta quantos termos da busca aparecem em qualquer um dos campos (no máximo um ponto por termo). */
+export function countTermMatches(terms: string[], fields: string[]): number {
+  if (terms.length === 0) return 0
+  return terms.reduce(
+    (count, term) => count + (termMatchesInFields(term, fields) ? 1 : 0),
+    0
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,7 +1825,7 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-s390x" "1.0.4"
 
-"@img/sharp-linux-x64@0.33.5", "@img/sharp-linux-x64@^0.33.5":
+"@img/sharp-linux-x64@0.33.5":
   version "0.33.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz#d806e0afd71ae6775cc87f0da8f2d03a7c2209cb"
   integrity sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,7 +1825,7 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-s390x" "1.0.4"
 
-"@img/sharp-linux-x64@0.33.5":
+"@img/sharp-linux-x64@0.33.5", "@img/sharp-linux-x64@^0.33.5":
   version "0.33.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz#d806e0afd71ae6775cc87f0da8f2d03a7c2209cb"
   integrity sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==


### PR DESCRIPTION
#### What is the purpose of this pull request?

Centralizes tokenized search in src/utils/search/tokenizedSearch.ts: stopwords by locale, splitting the query into terms, matching on configurable fields, and ranking by how many terms match before applying date ordering.

Pages updated: known-issues, troubleshooting, faq, announcements. Each passes its own searchable fields:

|Page | Fields | What each one represents|
|-- | -- | --|
|Known issues | Title | Problem name shown on the card and in the list.
  | ID | Internal KI reference (helps find an item by number/identifier even when it’s not in the title).
|Troubleshooting | Title | Troubleshooting article title.
  | Slug | File/URL identifier (useful when the user remembers part of the link or filename).
|FAQ | Title | FAQ question or title.
  | Slug | Article identifier in the URL.
  | Product team | Associated product team (supports matching by area, e.g. team name).
|Announcements | Title | Announcement headline.
  | Synopsis | Locale-specific synopsis from frontmatter (when present).
  | Tags (single string) | Announcement tags concatenated into one searchable string (type, area, etc.).



Add a “?” tooltip next to the search inputs on those pages (reusing the known-issues tooltip message id with sensible defaultMessages).

Fixes Next.js 13 Image deprecation by replacing objectFit with style={{ objectFit: 'cover' }} in newsletter-section; removes unused unlink import in Cypress plugin; removes @img/sharp-linux-x64 from required deps (it broke yarn install on macOS arm64). If kept for Linux CI, it should live under optionalDependencies so local arm64 installs still succeed.

#### What problem is this solving?

List searches used a single substring on the title. That made multi-word queries and common words (articles/prepositions) awkward and did not rank results by relevance. This aligns behavior across content types with the richer KI-style flow and improves developer experience on Apple Silicon by not forcing a Linux-only Sharp binary as a hard dependency.

#### How should this be manually tested?

1. yarn install and yarn dev on macOS arm64, install should complete (no @img/sharp-linux-x64 arch error if optional pattern is merged).
2. For each locale (/pt/..., /en/..., /es/...), open Known issues, Troubleshooting, FAQ, and Announcements.
3. Search with stopwords (e.g. “Admin login issue”), irrelevant words should be ignored; results should still match on remaining terms.
4. Search with multiple words, items with more matching terms should rank higher; tie-break by the page’s date rule.

#### Screenshots or example usage


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.