### PR TITLE
docs: add redirect for creating beta collections

### DIFF
--- a/public/redirects.json
+++ b/public/redirects.json
@@ -17600,6 +17600,10 @@
         "to": "/en/docs/tutorials/managing-admin-users"
       },
       {
+        "from": "/en/docs/tutorials/creating-beta-collections",
+        "to": "/docs/tracks/adding-collections-track"
+      },
+      {
         "from": "/v4",
         "to": "/en/docs/tutorials/vtex-admin-start-here"
       },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a manual redirect so requests to `/en/docs/tutorials/creating-beta-collections` are redirected to `/docs/tracks/adding-collections-track`.

#### What problem is this solving?

The old tutorial URL should now resolve to the collections track instead of staying on the legacy tutorial path.

#### How should this be manually tested?

1. Open `https://help.vtex.com/en/docs/tutorials/creating-beta-collections`.
2. Confirm it redirects to `https://help.vtex.com/docs/tracks/adding-collections-track`.
3. Open `https://help.vtex.com/en/docs/tutorials/creating-beta-collections#authorization`.
4. Confirm the browser still lands on `https://help.vtex.com/docs/tracks/adding-collections-track`.

#### Screenshots or example usage

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
