### PR TITLE
chore: ignore personal config files and temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,8 @@ cypress-test.log
 
 # Redirect tests
 /redirect tests/
+
+# personal configs and temporary files dir
+.claude/settings.json
+.vscode/settings.json
+temp/


### PR DESCRIPTION
Updated `.gitignore` to exclude personal configuration files and a temporary directory that should not be tracked in the repository.

## Why

Personal editor and tool configuration files are developer-specific and should not be committed to the shared repository. Adding these to `.gitignore` prevents accidental commits of local settings that may contain personal preferences, API keys, or machine-specific paths.
