### PR TITLE
test(cypress): add env block and search custom commands (EDU-18407)

### DIFF
--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -1,6 +1,9 @@
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
+  env: {
+    HYBRID_SEARCH_ENABLED: process.env.CYPRESS_HYBRID_SEARCH_ENABLED ?? 'true',
+  },
   video: false, // Disabled by default for speed; enable via CLI --config video=true if needed
   screenshotOnRunFailure: true,
   videosFolder: 'src/tests/cypress/videos',

--- a/src/tests/cypress/support/commands.js
+++ b/src/tests/cypress/support/commands.js
@@ -81,6 +81,20 @@ Cypress.Commands.add('verifyLocale', (expectedLocale) => {
   }
 })
 
+Cypress.Commands.add('searchFor', (query) => {
+  cy.get('[data-testid="search-input"]').clear().type(query)
+})
+
+Cypress.Commands.add('submitSearch', (query, via = 'enter') => {
+  cy.searchFor(query)
+  if (via === 'enter') {
+    cy.get('[data-testid="search-input"]').type('{enter}')
+  } else {
+    cy.get('[data-testid="search-button"]').click()
+  }
+  cy.url().should('include', '/search')
+})
+
 Cypress.Commands.add('clickSidebarLink', (options = {}) => {
   const { locale, index = 0 } = options
 


### PR DESCRIPTION
## Summary

- Adds `HYBRID_SEARCH_ENABLED` env var to the Cypress config `env` block (defaults to `'true'`, overridable via `CYPRESS_HYBRID_SEARCH_ENABLED`)
- Adds `cy.searchFor(query)` and `cy.submitSearch(query, via)` custom commands to `commands.js` for use in upcoming search test specs

## Test plan

- [ ] Existing specs (`copy-for-llm.cy.js`, `helpcenter-navigation-status.cy.js`, `locale-switching.cy.js`, `sidebar-navigation.cy.js`) still pass in CI
- [ ] No "cannot find custom command" errors in the Cypress output

Part of EDU-18407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)