### PR TITLE
EDU-18841: remove status gate from announcements listing

### DIFF
--- a/src/pages/announcements/index.tsx
+++ b/src/pages/announcements/index.tsx
@@ -346,11 +346,7 @@ export const getStaticProps: GetStaticProps = async ({
     for (const { content, slug } of batchResults) {
       if (!content) continue
       const frontmatter = await parseFrontmatter(content, logger)
-      // Only include published or changed announcements
-      if (
-        frontmatter &&
-        (frontmatter.status === 'PUBLISHED' || frontmatter.status === 'CHANGED')
-      ) {
+      if (frontmatter) {
         const tags: string[] =
           frontmatter.tags &&
           Array.isArray(frontmatter.tags) &&


### PR DESCRIPTION
Removes the status gate from the announcements listing so all announcements are included in the page, regardless of their `status` frontmatter value.

## Changes

- In `src/pages/announcements/index.tsx` (`getStaticProps`), drop the filter that only included announcements with `status === 'PUBLISHED'` or `status === 'CHANGED'`. Now every announcement with valid frontmatter is included.

## Why

Content visibility was being gated by the announcement `status` field, which is a deprecated field, not listed among the repository's front matter requirements. Besides, there are no announcements with status different than published, so this gate effectively barred only the announcements compliant with the new front matter contract rules.

## Related Task

[EDU-18841](https://vtex-dev.atlassian.net/browse/EDU-18841)
