### PR TITLE
fix: add scope prop to MarkdownRenderer in article-render

### DIFF
--- a/src/components/article-render/index.tsx
+++ b/src/components/article-render/index.tsx
@@ -166,6 +166,7 @@ const ArticleRender = ({
                   <MarkdownRenderer
                     serialized={serialized}
                     customComponents={{ InsertAccountName }}
+                    scope={{}}
                   />
                 </article>
               </Box>


### PR DESCRIPTION
## Summary
- Adds `scope={{}}` prop to `MarkdownRenderer` in `article-render` to align with the component's expected interface.