### PR TITLE
chore: bump vtex/components version to fix callout issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/http-proxy": "^1.17.9",
     "@types/probe-image-size": "^7.2.0",
     "@vtex/brand-ui": "^0.46.1",
-    "@vtexdocs/components": "https://github.com/vtexdocs/components.git#v6.1.1",
+    "@vtexdocs/components": "https://github.com/vtexdocs/components.git#v6.1.2",
     "algoliasearch": "^4.14.2",
     "chalk": "^5.2.0",
     "copy-text-to-clipboard": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/http-proxy": "^1.17.9",
     "@types/probe-image-size": "^7.2.0",
     "@vtex/brand-ui": "^0.46.1",
-    "@vtexdocs/components": "https://github.com/vtexdocs/components.git#v6.1.2",
+    "@vtexdocs/components": "https://github.com/vtexdocs/components.git#v6.1.3",
     "algoliasearch": "^4.14.2",
     "chalk": "^5.2.0",
     "copy-text-to-clipboard": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3420,8 +3420,8 @@
   resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.6.0.tgz#c9dfffc95d2ef55195237411f9c15269ca30b2a5"
   integrity sha512-SVQBxaSdEVdpJFja1aVTIiZBgpQKePyYOUWGzcYq6LYkSWqSbz2LoC7TuLUsmfweYmVkv8+4eVuxcDpQVEpq1A==
 
-"@vtexdocs/components@https://github.com/vtexdocs/components.git#v6.1.2":
-  version "6.1.2"
+"@vtexdocs/components@https://github.com/vtexdocs/components.git#v6.1.3":
+  version "6.1.3"
   resolved "https://github.com/vtexdocs/components.git#ab16f4c3feebc465865c4988f58ea0bc858ca6dc"
   dependencies:
     "@code-hike/mdx" "^0.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3420,9 +3420,9 @@
   resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.6.0.tgz#c9dfffc95d2ef55195237411f9c15269ca30b2a5"
   integrity sha512-SVQBxaSdEVdpJFja1aVTIiZBgpQKePyYOUWGzcYq6LYkSWqSbz2LoC7TuLUsmfweYmVkv8+4eVuxcDpQVEpq1A==
 
-"@vtexdocs/components@https://github.com/vtexdocs/components.git#v6.1.1":
-  version "6.1.1"
-  resolved "https://github.com/vtexdocs/components.git#3c45a84f0dbe5cb1f29c20de26231d860f6e8781"
+"@vtexdocs/components@https://github.com/vtexdocs/components.git#v6.1.2":
+  version "6.1.2"
+  resolved "https://github.com/vtexdocs/components.git#ab16f4c3feebc465865c4988f58ea0bc858ca6dc"
   dependencies:
     "@code-hike/mdx" "^0.9.0"
     "@vtex/brand-ui" "^0.46.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3420,9 +3420,9 @@
   resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.6.0.tgz#c9dfffc95d2ef55195237411f9c15269ca30b2a5"
   integrity sha512-SVQBxaSdEVdpJFja1aVTIiZBgpQKePyYOUWGzcYq6LYkSWqSbz2LoC7TuLUsmfweYmVkv8+4eVuxcDpQVEpq1A==
 
-"@vtexdocs/components@https://github.com/vtexdocs/components.git#v6.1.1":
-  version "6.1.1"
-  resolved "https://github.com/vtexdocs/components.git#3c45a84f0dbe5cb1f29c20de26231d860f6e8781"
+"@vtexdocs/components@https://github.com/vtexdocs/components.git#v6.1.3":
+  version "6.1.3"
+  resolved "https://github.com/vtexdocs/components.git#61ef8155f04b9f2dc16e08fa790ce5b44f8a0844"
   dependencies:
     "@code-hike/mdx" "^0.9.0"
     "@vtex/brand-ui" "^0.46.1"


### PR DESCRIPTION
#### What is the purpose of this pull request?

use new version of vtex/components to fix callout issues https://github.com/vtexdocs/components/commit/ab16f4c3feebc465865c4988f58ea0bc858ca6dc

like in devportal https://github.com/vtexdocs/devportal/pull/1331

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
