### PR TITLE
chore: add redirects for Intelligent Search Multilanguage doc

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -321,25 +321,25 @@ to = "/docs/tutorials/importar-e-exportar-imagens-de-produtos-e-skus-via-planilh
 force = true
 from = "/pt/docs/tutorials/vtex-intelligent-search-configuracoes-multi-idioma-beta"
 status = 308
-to = "/docs/tutorials/vtex-intelligent-search-configuracoes-multi-idioma"
+to = "/pt/docs/tutorials/vtex-intelligent-search-configuracoes-multi-idioma"
 
 [[redirects]]
 force = true
 from = "/en/docs/tutorials/vtex-intelligent-search-multilanguage-settings-beta"
 status = 308
-to = "/docs/tutorials/vtex-intelligent-search-multilanguage-settings"
+to = "/en/docs/tutorials/vtex-intelligent-search-multilanguage-settings"
 
 [[redirects]]
 force = true
 from = "/docs/tutorials/vtex-intelligent-search-multilanguage-settings-beta"
 status = 308
-to = "/docs/tutorials/vtex-intelligent-search-multilanguage-settings"
+to = "/en/docs/tutorials/vtex-intelligent-search-multilanguage-settings"
 
 [[redirects]]
 force = true
 from = "/es/docs/tutorials/vtex-intelligent-search-configuracion-multidioma-beta"
 status = 308
-to = "/docs/tutorials/vtex-intelligent-search-configuracion-multidioma"
+to = "/es/docs/tutorials/vtex-intelligent-search-configuracion-multidioma"
 
 [[redirects]]
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -319,6 +319,30 @@ to = "/docs/tutorials/importar-e-exportar-imagens-de-produtos-e-skus-via-planilh
 
 [[redirects]]
 force = true
+from = "/pt/docs/tutorials/vtex-intelligent-search-configuracoes-multi-idioma-beta"
+status = 308
+to = "/docs/tutorials/vtex-intelligent-search-configuracoes-multi-idioma"
+
+[[redirects]]
+force = true
+from = "/en/docs/tutorials/vtex-intelligent-search-multilanguage-settings-beta"
+status = 308
+to = "/docs/tutorials/vtex-intelligent-search-multilanguage-settings"
+
+[[redirects]]
+force = true
+from = "/docs/tutorials/vtex-intelligent-search-multilanguage-settings-beta"
+status = 308
+to = "/docs/tutorials/vtex-intelligent-search-multilanguage-settings"
+
+[[redirects]]
+force = true
+from = "/es/docs/tutorials/vtex-intelligent-search-configuracion-multidioma-beta"
+status = 308
+to = "/docs/tutorials/vtex-intelligent-search-configuracion-multidioma"
+
+[[redirects]]
+force = true
 from = "/pt/docs/tutorials/exportar-e-importar-especificacoes-de-produto-e-de-sku"
 status = 308
 to = "/docs/tutorials/importar-e-exportar-especificacoes-de-produtos-via-planilha"


### PR DESCRIPTION
[EDU-19059](https://vtex-dev.atlassian.net/browse/EDU-19059)

Adds netlify.toml redirects for the old beta URLs of the VTEX Intelligent Search Multilanguage settings doc (PT/EN/ES), which was moved out of beta in vtexdocs/help-center-content#971.