### PR TITLE
EDU-19260: add redirects for renamed buying-policies tutorial slugs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1126,3 +1126,15 @@ force = true
 from = "/pt/docs/tutorials/integracao-com-o-facebook-business-extension-fbe"
 status = 308
 to = "/pt/docs/tracks/integracao-com-o-meta-business-extension"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/buying-policies"
+status = 308
+to = "/pt/docs/tutorials/politicas-de-compras"
+
+[[redirects]]
+force = true
+from = "/pt/docs/tutorials/adicionar-ou-editar-buying-policies"
+status = 308
+to = "/pt/docs/tutorials/adicionar-ou-editar-politicas-de-compras"


### PR DESCRIPTION
Adds 308 redirects in `netlify.toml` for the renamed "Buying policies" tutorial slugs so old URLs continue to resolve.

## Related Task

[EDU-19260](https://vtex-dev.atlassian.net/browse/EDU-19260)
